### PR TITLE
Fixes needed for integration (CU-bar1zy and CU-bar0fm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Twilio message ID logs for the alert session.
+- A call to the `sessionChangedCallback` after sending the initial alert session message (CU-bar1zy).
 
 ## [1.0.0] - 2020-10-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Twilio message ID logs for the alert session.
 - A call to the `sessionChangedCallback` after sending the initial alert session message (CU-bar1zy).
+- helpers.isTestEnvironment helper method (CU-bar0fm).
+- try/catch blocks to better handle `UnhandledPromiseRejectionWarning`s (CU-bar0fm).
+
+### Changed
+- IncidentCategory handling (CU-bar0fm).
 
 ## [1.0.0] - 2020-10-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ In the test environment, returns the test version of the environment variable wi
 **Returns:** the correct environment variable for the situation.
 
 
+### isTestEnvironment()
+
+Determines whether we are executing in a test environment (i.e. with the value of NODE_ENV === 'test').
+
+**Returns:** `true` if the current execution is in a test environment. `false` otherwise.
+
 ### isValidRequest(req, properties)
 
 Determines whether the given Express request is valid if the given set of properties are required.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ An object representing an alert session. Contains the following fields:
 
 **alertState (ALERT_STATE):** Thc current alert state of the alert session
 
-**incidentCategoryKey (string):** The integer representing the incident category associated with the alert session
+**incidentCategoryKey (string):** The string representing the incident category associated with the alert session
 
 **details (string):** The incident details associated with the alert session
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ An object representing an alert session. Contains the following fields:
 
 **alertState (ALERT_STATE):** Thc current alert state of the alert session
 
-**incidentCategory (int):** The integer representing the incident category associated with the alert session
+**incidentCategoryKey (string):** The integer representing the incident category associated with the alert session
 
 **details (string):** The incident details associated with the alert session
 
@@ -153,15 +153,10 @@ An object representing an alert session. Contains the following fields:
 
 **responderPhoneNumber(string):** The phone number of th responder phone associated with the alert session
 
-**validIncidentCategories (object):** The valid incident cateogries for this session. The object keys are the values we expect the responder to return (for example '1' or '2'). The object values are the interpretation of these keys that will be stored in the DB. For example:
+**validIncidentCategoryKeys (array of strings):** The valid incident cateogry keys for this session. These are the values that the responder will use to select an incident category through text message. For example:
 
 ```
-{
-    '1': 'No One Inside',
-    '2': 'Person responded',
-    '3': 'Overdose',
-    '4': 'None of the above'
-}
+['1', '2', '3', '4']
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The main class of this library. It is used to send single alerts or to start ale
 
 **asksIncidentDetails (boolean):** `true` if alert sessions should ask for incident details, `false` otherwise
 
-**getReturnMessage (function(fromAlertState, toAlertState)):** function that returns the message to send back when there is a transition from `fromAlertState` to `toAlertState` (note that `fromAlertState` and `toAlertState` will have the same value for cases where a transition doesn't change the alert state)
+**getReturnMessage (function(fromAlertState, toAlertState, validIncidentCategories)):** function that returns the message to send back when there is a transition from `fromAlertState` to `toAlertState` (note that `fromAlertState` and `toAlertState` will have the same value for cases where a transition doesn't change the alert state). Sometimes this message needs to know the `validIncidentCategories` for the particular session.
 
 
 ### getRouter()
@@ -153,11 +153,24 @@ An object representing an alert session. Contains the following fields:
 
 **responderPhoneNumber(string):** The phone number of th responder phone associated with the alert session
 
+**validIncidentCategories (array of strings):** The valid incident cateogries for this session. These are the values that will
+be stored in the DB. For example:
+
+```
+['Accidental', 'Safer Use', 'Overdose', 'Other']
+```
+
+Note that these line up one-to-one with the `validIncidentCategoryKeys`. So for any `i`, `validIncidentCategories[i]` is the
+human-readable DB value for the `validIncidentCategoryKeys[i]` value given by the Responder in a text message.
+
 **validIncidentCategoryKeys (array of strings):** The valid incident cateogry keys for this session. These are the values that the responder will use to select an incident category through text message. For example:
 
 ```
 ['1', '2', '3', '4']
 ````
+
+Note that these line up one-to-one with the `validIncidentCategoryKeys`. So for any `i`, `validIncidentCategories[i]` is the
+human-readable DB value for the `validIncidentCategoryKeys[i]` value given by the Responder in a text message.
 
 
 ## `ALERT_STATE` enum

--- a/lib/alertSession.js
+++ b/lib/alertSession.js
@@ -1,5 +1,5 @@
 class AlertSession {
-    constructor(sessionId, alertState, incidentCategoryKey, details, fallbackReturnMessage, responderPhoneNumber, validIncidentCategoryKeys) {
+    constructor(sessionId, alertState, incidentCategoryKey, details, fallbackReturnMessage, responderPhoneNumber, validIncidentCategoryKeys, validIncidentCategories) {
         this.sessionId = sessionId
         this.alertState = alertState
         this.incidentCategoryKey = incidentCategoryKey
@@ -7,6 +7,7 @@ class AlertSession {
         this.fallbackReturnMessage = fallbackReturnMessage
         this.responderPhoneNumber = responderPhoneNumber
         this.validIncidentCategoryKeys = validIncidentCategoryKeys
+        this.validIncidentCategories = validIncidentCategories
     }
 }
 

--- a/lib/alertSession.js
+++ b/lib/alertSession.js
@@ -1,12 +1,12 @@
 class AlertSession {
-    constructor(sessionId, alertState, incidentCategory, details, fallbackReturnMessage, responderPhoneNumber, validIncidentCategories) {
+    constructor(sessionId, alertState, incidentCategoryKey, details, fallbackReturnMessage, responderPhoneNumber, validIncidentCategoryKeys) {
         this.sessionId = sessionId
         this.alertState = alertState
-        this.incidentCategory = incidentCategory
+        this.incidentCategoryKey = incidentCategoryKey
         this.details = details
         this.fallbackReturnMessage = fallbackReturnMessage
         this.responderPhoneNumber = responderPhoneNumber
-        this.validIncidentCategories = validIncidentCategories
+        this.validIncidentCategoryKeys = validIncidentCategoryKeys
     }
 }
 

--- a/lib/alertStateMachine.js
+++ b/lib/alertStateMachine.js
@@ -18,7 +18,7 @@ class AlertStateMachine {
                 break
 
             case ALERT_STATE.WAITING_FOR_CATEGORY:
-                if (messageText.trim() in validIncidentCategoryKeys) {
+                if (validIncidentCategoryKeys.indexOf(messageText.trim()) >= 0) {
                     incidentCategoryKey = messageText.trim()
                     nextAlertState = this.asksIncidentDetails ? ALERT_STATE.WAITING_FOR_DETAILS : nextAlertState = ALERT_STATE.COMPLETED
                 } else {

--- a/lib/alertStateMachine.js
+++ b/lib/alertStateMachine.js
@@ -11,9 +11,9 @@ class AlertStateMachine {
         this.getReturnMessage = getReturnMessage
     }
 
-    processStateTransitionWithMessage(currentAlertState, messageText, validIncidentCategories) {
+    processStateTransitionWithMessage(currentAlertState, messageText, validIncidentCategoryKeys) {
         let nextAlertState
-        let incidentCategory
+        let incidentCategoryKey
         let details
 
         switch (currentAlertState) {
@@ -23,8 +23,8 @@ class AlertStateMachine {
                 break
 
             case ALERT_STATE.WAITING_FOR_CATEGORY:
-                if (messageText.trim() in validIncidentCategories) {
-                    incidentCategory = messageText.trim()
+                if (messageText.trim() in validIncidentCategoryKeys) {
+                    incidentCategoryKey = messageText.trim()
                     nextAlertState = this.asksIncidentDetails ? ALERT_STATE.WAITING_FOR_DETAILS : nextAlertState = ALERT_STATE.COMPLETED
                 } else {
                     nextAlertState = currentAlertState
@@ -45,7 +45,7 @@ class AlertStateMachine {
 
         return {
             nextAlertState: nextAlertState,
-            incidentCategory: incidentCategory,
+            incidentCategoryKey: incidentCategoryKey,
             details: details,
             returnMessage: this.getReturnMessage(currentAlertState, nextAlertState),
         }

--- a/lib/alertStateMachine.js
+++ b/lib/alertStateMachine.js
@@ -1,17 +1,12 @@
 const ALERT_STATE = require('./alertStateEnum.js')
 
 class AlertStateMachine {
-    // asksIncidentDetails (Boolean)
-    //    true if the user should be asked about the incident details.
-    // getReturnMessage (Function)
-    //    Takes two parameters: the current AlertState and the next AlertState
-    //    Returns the message to send to the user for that state transition
     constructor (asksIncidentDetails, getReturnMessage) {
         this.asksIncidentDetails = asksIncidentDetails
         this.getReturnMessage = getReturnMessage
     }
 
-    processStateTransitionWithMessage(currentAlertState, messageText, validIncidentCategoryKeys) {
+    processStateTransitionWithMessage(currentAlertState, messageText, validIncidentCategoryKeys, validIncidentCategories) {
         let nextAlertState
         let incidentCategoryKey
         let details
@@ -47,7 +42,7 @@ class AlertStateMachine {
             nextAlertState: nextAlertState,
             incidentCategoryKey: incidentCategoryKey,
             details: details,
-            returnMessage: this.getReturnMessage(currentAlertState, nextAlertState),
+            returnMessage: this.getReturnMessage(currentAlertState, nextAlertState, validIncidentCategories),
         }
     }
 }

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -28,11 +28,17 @@ class BraveAlerter {
     }
 
     async sendSingleAlert(toPhoneNumber, fromPhoneNumber, message) {
-        const response = await twilio.sendTwilioMessage(
-            toPhoneNumber,
-            fromPhoneNumber,
-            message
-        )
+        let response
+        try {
+            response = await twilio.sendTwilioMessage(
+                toPhoneNumber,
+                fromPhoneNumber,
+                message
+            )
+        } catch (err) {
+            // Error handling will be done below because response is undefined
+            helpers.log(err)
+        }
 
         if (response !== undefined) {
             helpers.log(response.sid)
@@ -44,16 +50,21 @@ class BraveAlerter {
     // See README for description of alertInfo
     async startAlertSession(alertInfo) {
         let response
-
+        
         // Send initial message
         if (alertInfo.toPhoneNumber && alertInfo.fromPhoneNumber) {
-            response = await twilio.sendTwilioMessage(
-                alertInfo.toPhoneNumber,
-                alertInfo.fromPhoneNumber,
-                alertInfo.message
-            )
+            try {
+                response = await twilio.sendTwilioMessage(
+                    alertInfo.toPhoneNumber,
+                    alertInfo.fromPhoneNumber,
+                    alertInfo.message
+                )
+            } catch (err) {
+                // Error handling will be done below because response is undefined
+                helpers.log(err)
+            }
         }
-        
+            
         if (response !== undefined) {
             const changedAlertSession = new AlertSession(
                 alertInfo.sessionId,
@@ -87,58 +98,68 @@ class BraveAlerter {
     }
 
     async sendReminderMessageForSession(alertInfo) {
-        const alertSession = await this.getAlertSession(alertInfo.sessionId)
+        try {
+            const alertSession = await this.getAlertSession(alertInfo.sessionId)
 
-        if (alertSession.alertState === ALERT_STATE.STARTED) {
-            // Send reminder message
-            if (alertInfo.toPhoneNumber && alertInfo.fromPhoneNumber) {
-                const response = await twilio.sendTwilioMessage(
-                    alertInfo.toPhoneNumber,
-                    alertInfo.fromPhoneNumber,
-                    alertInfo.reminderMessage
-                )
-
-                if (response) {
-                    const changedAlertSession = new AlertSession(
-                        alertInfo.sessionId,
-                        ALERT_STATE.WAITING_FOR_REPLY,
+            if (alertSession.alertState === ALERT_STATE.STARTED) {
+                // Send reminder message
+                if (alertInfo.toPhoneNumber && alertInfo.fromPhoneNumber) {
+                    const response = await twilio.sendTwilioMessage(
+                        alertInfo.toPhoneNumber,
+                        alertInfo.fromPhoneNumber,
+                        alertInfo.reminderMessage
                     )
-                    await this.alertSessionChangedCallback(changedAlertSession)
 
-                    helpers.log(response.sid)
-                } else {
-                    // TODO Better error handling (maybe try to send the fallback message immediately)
-                    helpers.log(`Failed to send reminder message for session ${alertInfo.sessionId}`)
+                    if (response) {
+                        const changedAlertSession = new AlertSession(
+                            alertInfo.sessionId,
+                            ALERT_STATE.WAITING_FOR_REPLY,
+                        )
+                        await this.alertSessionChangedCallback(changedAlertSession)
+
+                        helpers.log(response.sid)
+                    } else {
+                        // TODO Better error handling (maybe try to send the fallback message immediately)
+                        helpers.log(`Failed to send reminder message for session ${alertInfo.sessionId}`)
+                    }
                 }
             }
+        } catch (err) {
+            // TODO Better error handling (maybe try to send the fallback message immediately)
+            helpers.log(`Failed to send reminder message for session ${alertInfo.sessionId}. ${JSON.stringify(err)}`)
         }
     }
 
     async sendFallbackMessageForSession(alertInfo) {
-        const alertSession = await this.getAlertSession(alertInfo.sessionId)
+        try {
+            const alertSession = await this.getAlertSession(alertInfo.sessionId)
 
-        if (alertSession.alertState === ALERT_STATE.WAITING_FOR_REPLY) {
-            // Send fallback alert
-            if (alertInfo.fallbackToPhoneNumber && alertInfo.fallbackFromPhoneNumber) {
-                const response = await twilio.sendTwilioMessage(
-                    alertInfo.fallbackToPhoneNumber,
-                    alertInfo.fallbackFromPhoneNumber,
-                    alertInfo.fallbackMessage
-                )
-
-                if (response) {
-                    const changedAlertSession = new AlertSession(
-                        alertInfo.sessionId,
+            if (alertSession.alertState === ALERT_STATE.WAITING_FOR_REPLY) {
+                // Send fallback alert
+                if (alertInfo.fallbackToPhoneNumber && alertInfo.fallbackFromPhoneNumber) {
+                    const response = await twilio.sendTwilioMessage(
+                        alertInfo.fallbackToPhoneNumber,
+                        alertInfo.fallbackFromPhoneNumber,
+                        alertInfo.fallbackMessage
                     )
-                    changedAlertSession.fallbackReturnMessage = response.status
-                    await this.alertSessionChangedCallback(changedAlertSession)
 
-                    helpers.log(response.sid)
-                } else {
-                    // TODO Better error handling
-                    helpers.log(`Failed to send fallback for session ${alertInfo.sessionId}`)
+                    if (response) {
+                        const changedAlertSession = new AlertSession(
+                            alertInfo.sessionId,
+                        )
+                        changedAlertSession.fallbackReturnMessage = response.status
+                        await this.alertSessionChangedCallback(changedAlertSession)
+
+                        helpers.log(response.sid)
+                    } else {
+                        // TODO Better error handling
+                        helpers.log(`Failed to send fallback for session ${alertInfo.sessionId}`)
+                    }
                 }
             }
+        } catch (err) {
+            // TODO Better error handling
+            helpers.log(`Failed to send fallback for session ${alertInfo.sessionId}. ${JSON.stringify(err)}`)
         }
     }
 

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -171,7 +171,7 @@ class BraveAlerter {
 
             // Process the message through the state machine
             const { nextAlertState, incidentCategoryKey, details, returnMessage }
-                    = this.alertStateMachine.processStateTransitionWithMessage(alertSession.alertState, message, alertSession.validIncidentCategoryKeys)
+                    = this.alertStateMachine.processStateTransitionWithMessage(alertSession.alertState, message, alertSession.validIncidentCategoryKeys, alertSession.validIncidentCategories)
 
             // Store the results
             const changedAlertSession = new AlertSession(

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -164,21 +164,20 @@ class BraveAlerter {
 
             // Ensure message was sent from the Responder phone
             if (fromPhoneNumber !== alertSession.responderPhoneNumber) {
-                console.log(`***TKD fromPhoneNumber: ${fromPhoneNumber}, responderPhoneNumber: ${alertSession.responderPhoneNumber}`)
                 helpers.log('Invalid Phone Number')
                 response.status(400).send()
                 return
             }
 
             // Process the message through the state machine
-            const { nextAlertState, incidentCategory, details, returnMessage }
-                    = this.alertStateMachine.processStateTransitionWithMessage(alertSession.alertState, message, alertSession.validIncidentCategories)
+            const { nextAlertState, incidentCategoryKey, details, returnMessage }
+                    = this.alertStateMachine.processStateTransitionWithMessage(alertSession.alertState, message, alertSession.validIncidentCategoryKeys)
 
             // Store the results
             const changedAlertSession = new AlertSession(
                 alertSession.sessionId,
                 nextAlertState,
-                incidentCategory,
+                incidentCategoryKey,
                 details,
             )
             await this.alertSessionChangedCallback(changedAlertSession)

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -43,20 +43,26 @@ class BraveAlerter {
 
     // See README for description of alertInfo
     async startAlertSession(alertInfo) {
-        let isAlertSent = false
+        let response
 
         // Send initial message
         if (alertInfo.toPhoneNumber && alertInfo.fromPhoneNumber) {
-            const response = await twilio.sendTwilioMessage(
+            response = await twilio.sendTwilioMessage(
                 alertInfo.toPhoneNumber,
                 alertInfo.fromPhoneNumber,
                 alertInfo.message
             )
-
-            isAlertSent = (response !== undefined)
         }
+        
+        if (response !== undefined) {
+            const changedAlertSession = new AlertSession(
+                alertInfo.sessionId,
+                ALERT_STATE.STARTED,
+            )
+            await this.alertSessionChangedCallback(changedAlertSession)
 
-        if (!isAlertSent) {
+            helpers.log(response.sid)
+        } else {
             // TODO Better error handling
             helpers.log(`Failed to send alert for session ${alertInfo.sessionId}`)
         }
@@ -98,6 +104,8 @@ class BraveAlerter {
                         ALERT_STATE.WAITING_FOR_REPLY,
                     )
                     await this.alertSessionChangedCallback(changedAlertSession)
+
+                    helpers.log(response.sid)
                 } else {
                     // TODO Better error handling (maybe try to send the fallback message immediately)
                     helpers.log(`Failed to send reminder message for session ${alertInfo.sessionId}`)
@@ -124,6 +132,8 @@ class BraveAlerter {
                     )
                     changedAlertSession.fallbackReturnMessage = response.status
                     await this.alertSessionChangedCallback(changedAlertSession)
+
+                    helpers.log(response.sid)
                 } else {
                     // TODO Better error handling
                     helpers.log(`Failed to send fallback for session ${alertInfo.sessionId}`)

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -164,6 +164,7 @@ class BraveAlerter {
 
             // Ensure message was sent from the Responder phone
             if (fromPhoneNumber !== alertSession.responderPhoneNumber) {
+                console.log(`***TKD fromPhoneNumber: ${fromPhoneNumber}, responderPhoneNumber: ${alertSession.responderPhoneNumber}`)
                 helpers.log('Invalid Phone Number')
                 response.status(400).send()
                 return

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -40,9 +40,7 @@ class BraveAlerter {
             helpers.log(err)
         }
 
-        if (response !== undefined) {
-            helpers.log(response.sid)
-        } else {
+        if (response === undefined) {
             helpers.log(`Failed to send single alert: ${message}`)
         }
     }
@@ -71,8 +69,6 @@ class BraveAlerter {
                 ALERT_STATE.STARTED,
             )
             await this.alertSessionChangedCallback(changedAlertSession)
-
-            helpers.log(response.sid)
         } else {
             // TODO Better error handling
             helpers.log(`Failed to send alert for session ${alertInfo.sessionId}`)
@@ -116,8 +112,6 @@ class BraveAlerter {
                             ALERT_STATE.WAITING_FOR_REPLY,
                         )
                         await this.alertSessionChangedCallback(changedAlertSession)
-
-                        helpers.log(response.sid)
                     } else {
                         // TODO Better error handling (maybe try to send the fallback message immediately)
                         helpers.log(`Failed to send reminder message for session ${alertInfo.sessionId}`)
@@ -149,8 +143,6 @@ class BraveAlerter {
                         )
                         changedAlertSession.fallbackReturnMessage = response.status
                         await this.alertSessionChangedCallback(changedAlertSession)
-
-                        helpers.log(response.sid)
                     } else {
                         // TODO Better error handling
                         helpers.log(`Failed to send fallback for session ${alertInfo.sessionId}`)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -15,6 +15,10 @@ function getEnvVar(name) {
     return process.env.NODE_ENV === 'test' ? process.env[name + '_TEST'] : process.env[name]
 }
 
+function isTestEnvironment() {
+    return process.env.NODE_ENV === 'test'
+}
+
 function isValidRequest(req, properties) {
     const hasAllProperties = (hasAllPropertiesSoFar, currentProperty) => hasAllPropertiesSoFar && Object.prototype.hasOwnProperty.call(req.body, currentProperty)
     return properties.reduce(hasAllProperties, true)
@@ -36,6 +40,7 @@ function sleep(millis) {
 
 module.exports = {
     getEnvVar,
+    isTestEnvironment,
     isValidRequest,
     log,
     sleep,

--- a/test/integration/testFallbackFlow.js
+++ b/test/integration/testFallbackFlow.js
@@ -25,9 +25,7 @@ const sessionId = 'guid-123'
 const responderPhoneNumber = '+15147886598'
 const devicePhoneNumber = '+15005550006'
 const initialMessage = 'Ok'
-const validIncidentCategories = {
-    '1': 'one',
-}
+const validIncidentCategoryKeys = ['1']
 const initialAlertInfo = {
     sessionId: sessionId,
     toPhoneNumber: responderPhoneNumber,
@@ -50,7 +48,7 @@ describe('fallback flow: responder never responds so fallback message is sent to
             undefined,
             undefined,
             responderPhoneNumber,
-            validIncidentCategories,
+            validIncidentCategoryKeys,
         )
 
         this.braveAlerter = new BraveAlerter(

--- a/test/integration/testFallbackFlow.js
+++ b/test/integration/testFallbackFlow.js
@@ -78,12 +78,18 @@ describe('fallback flow: responder never responds so fallback message is sent to
     it('', async function() {
         // Initial alert sent to responder phone
         await this.braveAlerter.startAlertSession(initialAlertInfo)
+
+        // Expect the state to change to STARTED
+        expect(this.braveAlerter.alertSessionChangedCallback.getCall(0).args[0]).to.eql(new AlertSession(
+            sessionId,
+            ALERT_STATE.STARTED,
+        ))
         
         // Wait for the reminder to send
         await helpers.sleep(2000)
         
         // Expect the state to change to WAITING_FOR_REPLY
-        expect(this.braveAlerter.alertSessionChangedCallback.getCall(0).args[0]).to.eql(new AlertSession(
+        expect(this.braveAlerter.alertSessionChangedCallback.getCall(1).args[0]).to.eql(new AlertSession(
             sessionId,
             ALERT_STATE.WAITING_FOR_REPLY,
         ))
@@ -94,7 +100,7 @@ describe('fallback flow: responder never responds so fallback message is sent to
         await helpers.sleep(3000)
 
         // Expect the fallback return message from a successful Twilio request to be 'queued'
-        expect(this.braveAlerter.alertSessionChangedCallback.getCall(1).args[0]).to.eql(new AlertSession(
+        expect(this.braveAlerter.alertSessionChangedCallback.getCall(2).args[0]).to.eql(new AlertSession(
             sessionId,
             undefined,
             undefined,

--- a/test/integration/testHappyPath.js
+++ b/test/integration/testHappyPath.js
@@ -84,6 +84,14 @@ describe('happy path integration test: responder responds right away and provide
         // Initial alert sent to responder phone
         await this.braveAlerter.startAlertSession(initialAlertInfo)
 
+        // Expect the state to change to STARTED
+        expect(this.braveAlerter.alertSessionChangedCallback).to.be.calledWith(new AlertSession(
+            sessionId,
+            ALERT_STATE.STARTED,
+        ))
+
+        this.currentAlertSession.alertState = ALERT_STATE.WAITING_FOR_CATEGORY
+
         // Responder replies 'Ok'
         let response = await chai.request(this.app).post('/alert/sms').send({
             From: responderPhoneNumber,

--- a/test/integration/testHappyPath.js
+++ b/test/integration/testHappyPath.js
@@ -10,7 +10,7 @@ const AlertSession = require('../../lib/alertSession.js')
 const ALERT_STATE = require('./../../lib/alertStateEnum.js')
 const BraveAlerter = require ('./../../lib/braveAlerter.js')
 
-chai.use(chaiHttp);
+chai.use(chaiHttp)
 chai.use(sinonChai)
 
 const dummyGetAlertSession = function() { return 'getAlertSession' }

--- a/test/integration/testHappyPath.js
+++ b/test/integration/testHappyPath.js
@@ -24,11 +24,9 @@ const sessionId = 'guid-123'
 const responderPhoneNumber = '+15147886598'
 const devicePhoneNumber = '+15005550006'
 const initialMessage = 'Ok'
-const incidentCategory = '1'
+const incidentCategoryKey = '1'
 const details = 'my details'
-const validIncidentCategories = {
-    '1': 'one',
-}
+const validIncidentCategoryKeys = ['1', '2']
 const initialAlertInfo = {
     sessionId: sessionId,
     toPhoneNumber: responderPhoneNumber,
@@ -53,7 +51,7 @@ describe('happy path integration test: responder responds right away and provide
             undefined,
             undefined,
             responderPhoneNumber,
-            validIncidentCategories,
+            validIncidentCategoryKeys,
         )
 
         this.braveAlerter = new BraveAlerter(
@@ -112,7 +110,7 @@ describe('happy path integration test: responder responds right away and provide
         response = await chai.request(this.app).post('/alert/sms').send({
             From: responderPhoneNumber,
             To: devicePhoneNumber,
-            Body: incidentCategory,
+            Body: incidentCategoryKey,
         })
         expect(response).to.have.status(200)
 
@@ -120,11 +118,11 @@ describe('happy path integration test: responder responds right away and provide
         expect(this.braveAlerter.alertSessionChangedCallback).to.be.calledWith(new AlertSession(
             sessionId,
             ALERT_STATE.WAITING_FOR_DETAILS,
-            incidentCategory,
+            incidentCategoryKey,
         ))
 
         this.currentAlertSession.alertState = ALERT_STATE.WAITING_FOR_DETAILS
-        this.currentAlertSession.incidentCategory = incidentCategory
+        this.currentAlertSession.incidentCategoryKey = incidentCategoryKey
 
         // Responder replies with incident details
         response = await chai.request(this.app).post('/alert/sms').send({

--- a/test/unit/testAlertStateMachine.js
+++ b/test/unit/testAlertStateMachine.js
@@ -98,10 +98,16 @@ describe('alertStateMachine.js unit tests:', function() {
                         expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_DETAILS)
                     })
     
-                    it('should change the incident category to the message text', function() {
-                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                    it('should change the incident category to the message text for first valid key', function() {
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '1', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
-                        expect(incidentCategoryKey).to.equal('3')
+                        expect(incidentCategoryKey).to.equal('1')
+                    })
+
+                    it('should change the incident category to the message text for last valid key', function() {
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '4', dummyIncidentCategoryKeys, dummyIncidentCategories)
+    
+                        expect(incidentCategoryKey).to.equal('4')
                     })
 
                     it('should change the incident category to the trimmed message text', function() {
@@ -123,28 +129,80 @@ describe('alertStateMachine.js unit tests:', function() {
                     })
                 })
 
-                describe('and messageText does not contain a valid incident category', function() {
+                describe('and messageText does not contain a valid incident category (too low)', function() {
                     it('should stay in WAITING_FOR_CATEGORY', function () {
-                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '0', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
                         expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_CATEGORY)
                     })
     
                     it('should not change the incident category', function() {
-                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '  2A3  ', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '0', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
                         expect(incidentCategoryKey).to.be.undefined
                     })
     
                     it('should not change the details', function() {
-                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '0', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
                         expect(details).to.be.undefined
                     })
     
                     it('should give the return message for WAITING_FOR_CATEGORY --> WAITING_FOR_CATEGORY', function() {
-                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '0', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
+                        expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_CATEGORY} --> ${ALERT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`)
+                    })
+                })
+                
+                describe('and messageText does not contain a valid incident category (too high)', function() {
+                    it('should stay in WAITING_FOR_CATEGORY', function () {
+                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        
+                        expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_CATEGORY)
+                    })
+                    
+                    it('should not change the incident category', function() {
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        
+                        expect(incidentCategoryKey).to.be.undefined
+                    })
+                    
+                    it('should not change the details', function() {
+                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        
+                        expect(details).to.be.undefined
+                    })
+                    
+                    it('should give the return message for WAITING_FOR_CATEGORY --> WAITING_FOR_CATEGORY', function() {
+                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        
+                        expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_CATEGORY} --> ${ALERT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`)
+                    })
+                })
+                
+                describe('and messageText does not contain a valid incident category (non-numeric)', function() {
+                    it('should stay in WAITING_FOR_CATEGORY', function () {
+                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '2A3', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        
+                        expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_CATEGORY)
+                    })
+                    
+                    it('should not change the incident category', function() {
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '  2A3  ', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        
+                        expect(incidentCategoryKey).to.be.undefined
+                    })
+                    
+                    it('should not change the details', function() {
+                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '2A3', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        
+                        expect(details).to.be.undefined
+                    })
+                    
+                    it('should give the return message for WAITING_FOR_CATEGORY --> WAITING_FOR_CATEGORY', function() {
+                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '2A3', dummyIncidentCategoryKeys, dummyIncidentCategories)
+                        
                         expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_CATEGORY} --> ${ALERT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`)
                     })
                 })

--- a/test/unit/testAlertStateMachine.js
+++ b/test/unit/testAlertStateMachine.js
@@ -4,11 +4,12 @@ const { beforeEach, describe, it } = require('mocha')
 const ALERT_STATE = require('./../../lib/alertStateEnum.js')
 const AlertStateMachine = require('../../lib/alertStateMachine.js')
 
-function dummyGetRetunMessages(fromAlertState, toAlertState) {
-    return `${fromAlertState} --> ${toAlertState}`
+function dummyGetRetunMessages(fromAlertState, toAlertState, incidentCategories) {
+    return `${fromAlertState} --> ${toAlertState} with ${JSON.stringify(incidentCategories)}`
 }
 
 const dummyIncidentCategoryKeys = ['1', '2', '3', '4']
+const dummyIncidentCategories = ['One', 'Two', 'Three', 'Four']
 
 describe('alertStateMachine.js unit tests:', function() {
     describe('constructor', function() {
@@ -39,171 +40,171 @@ describe('alertStateMachine.js unit tests:', function() {
 
             describe('given alert state is STARTED', function() {
                 it('should transition to WAITING_FOR_CATEGORY', function () {
-                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys)
+                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_CATEGORY)
                 })
 
                 it('should not change the incident category', function() {
-                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys)
+                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(incidentCategoryKey).to.be.undefined
                 })
 
                 it('should not change the details', function() {
-                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys)
+                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(details).to.be.undefined
                 })
 
                 it('should give the return message for STARTED --> WAITING_FOR_CATEGORY', function() {
-                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys)
+                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
-                    expect(returnMessage).to.equal(`${ALERT_STATE.STARTED} --> ${ALERT_STATE.WAITING_FOR_CATEGORY}`)
+                    expect(returnMessage).to.equal(`${ALERT_STATE.STARTED} --> ${ALERT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`)
                 })
             })
 
             describe('given alert state is WAITING_FOR_REPLY', function() {
                 it('should transition to WAITING_FOR_CATEGORY', function () {
-                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys)
+                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_CATEGORY)
                 })
 
                 it('should not change the incident category', function() {
-                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys)
+                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(incidentCategoryKey).to.be.undefined
                 })
 
                 it('should not change the details', function() {
-                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys)
+                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(details).to.be.undefined
                 })
 
                 it('should give the return message for WAITING_FOR_REPLY --> WAITING_FOR_CATEGORY', function() {
-                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys)
+                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
-                    expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_REPLY} --> ${ALERT_STATE.WAITING_FOR_CATEGORY}`)
+                    expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_REPLY} --> ${ALERT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`)
                 })
             })
 
             describe('given alert state is WAITING_FOR_CATEGORY', function() {
                 describe('and messageText contains a valid incident category', function () {
                     it('should transition to WAITING_FOR_DETAILS', function () {
-                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys)
+                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
                         expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_DETAILS)
                     })
     
                     it('should change the incident category to the message text', function() {
-                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys)
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
                         expect(incidentCategoryKey).to.equal('3')
                     })
 
                     it('should change the incident category to the trimmed message text', function() {
-                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '   2    ', dummyIncidentCategoryKeys)
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '   2    ', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
                         expect(incidentCategoryKey).to.equal('2')
                     })
     
                     it('should not change the details', function() {
-                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys)
+                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
                         expect(details).to.be.undefined
                     })
     
                     it('should give the return message for WAITING_FOR_CATEGORY --> WAITING_FOR_DETAILS', function() {
-                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys)
+                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
-                        expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_CATEGORY} --> ${ALERT_STATE.WAITING_FOR_DETAILS}`)
+                        expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_CATEGORY} --> ${ALERT_STATE.WAITING_FOR_DETAILS} with ["One","Two","Three","Four"]`)
                     })
                 })
 
                 describe('and messageText does not contain a valid incident category', function() {
                     it('should stay in WAITING_FOR_CATEGORY', function () {
-                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys)
+                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
                         expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_CATEGORY)
                     })
     
                     it('should not change the incident category', function() {
-                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '  2A3  ', dummyIncidentCategoryKeys)
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '  2A3  ', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
                         expect(incidentCategoryKey).to.be.undefined
                     })
     
                     it('should not change the details', function() {
-                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys)
+                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
                         expect(details).to.be.undefined
                     })
     
                     it('should give the return message for WAITING_FOR_CATEGORY --> WAITING_FOR_CATEGORY', function() {
-                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys)
+                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys, dummyIncidentCategories)
     
-                        expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_CATEGORY} --> ${ALERT_STATE.WAITING_FOR_CATEGORY}`)
+                        expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_CATEGORY} --> ${ALERT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`)
                     })
                 })
             })
 
             describe('given alert state is WAITING_FOR_DETAILS', function() {
                 it('should transition to COMPLETED', function () {
-                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys)
+                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(nextAlertState).to.equal(ALERT_STATE.COMPLETED)
                 })
 
                 it('should not change the incident category', function() {
-                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys)
+                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(incidentCategoryKey).to.be.undefined
                 })
 
                 it('should change the details to the message text', function() {
-                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys)
+                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(details).to.equal('3')
                 })
 
                 it('should change the details to the trimmed message text', function() {
-                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '    many    details    ', dummyIncidentCategoryKeys)
+                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '    many    details    ', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(details).to.equal('many    details')
                 })
 
                 it('should give the return message for WAITING_FOR_DETAILS --> COMPLETED', function() {
-                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys)
+                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
-                    expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_DETAILS} --> ${ALERT_STATE.COMPLETED}`)
+                    expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_DETAILS} --> ${ALERT_STATE.COMPLETED} with ["One","Two","Three","Four"]`)
                 })
             })
 
             describe('given alert state is COMPLETED', function() {
                 it('should stay in COMPLETED', function () {
-                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys)
+                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(nextAlertState).to.equal(ALERT_STATE.COMPLETED)
                 })
 
                 it('should not change the incident category', function() {
-                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys)
+                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(incidentCategoryKey).to.be.undefined
                 })
 
                 it('should not change the details', function() {
-                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys)
+                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
                     expect(details).to.be.undefined
                 })
 
                 it('should give the return message for COMPLETED --> COMPLETED', function() {
-                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys)
+                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys, dummyIncidentCategories)
 
-                    expect(returnMessage).to.equal(`${ALERT_STATE.COMPLETED} --> ${ALERT_STATE.COMPLETED}`)
+                    expect(returnMessage).to.equal(`${ALERT_STATE.COMPLETED} --> ${ALERT_STATE.COMPLETED} with ["One","Two","Three","Four"]`)
                 })
             })
         })

--- a/test/unit/testAlertStateMachine.js
+++ b/test/unit/testAlertStateMachine.js
@@ -8,12 +8,7 @@ function dummyGetRetunMessages(fromAlertState, toAlertState) {
     return `${fromAlertState} --> ${toAlertState}`
 }
 
-const dummyIncidentCategories = {
-    '1': 'One',
-    '2': 'Two',
-    '3': 'Three',
-    '4': 'Four'
-}
+const dummyIncidentCategoryKeys = ['1', '2', '3', '4']
 
 describe('alertStateMachine.js unit tests:', function() {
     describe('constructor', function() {
@@ -44,25 +39,25 @@ describe('alertStateMachine.js unit tests:', function() {
 
             describe('given alert state is STARTED', function() {
                 it('should transition to WAITING_FOR_CATEGORY', function () {
-                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategories)
+                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys)
 
                     expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_CATEGORY)
                 })
 
                 it('should not change the incident category', function() {
-                    const { incidentCategory } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategories)
+                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys)
 
-                    expect(incidentCategory).to.be.undefined
+                    expect(incidentCategoryKey).to.be.undefined
                 })
 
                 it('should not change the details', function() {
-                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategories)
+                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys)
 
                     expect(details).to.be.undefined
                 })
 
                 it('should give the return message for STARTED --> WAITING_FOR_CATEGORY', function() {
-                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategories)
+                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.STARTED, '3', dummyIncidentCategoryKeys)
 
                     expect(returnMessage).to.equal(`${ALERT_STATE.STARTED} --> ${ALERT_STATE.WAITING_FOR_CATEGORY}`)
                 })
@@ -70,25 +65,25 @@ describe('alertStateMachine.js unit tests:', function() {
 
             describe('given alert state is WAITING_FOR_REPLY', function() {
                 it('should transition to WAITING_FOR_CATEGORY', function () {
-                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategories)
+                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys)
 
                     expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_CATEGORY)
                 })
 
                 it('should not change the incident category', function() {
-                    const { incidentCategory } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategories)
+                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys)
 
-                    expect(incidentCategory).to.be.undefined
+                    expect(incidentCategoryKey).to.be.undefined
                 })
 
                 it('should not change the details', function() {
-                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategories)
+                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys)
 
                     expect(details).to.be.undefined
                 })
 
                 it('should give the return message for WAITING_FOR_REPLY --> WAITING_FOR_CATEGORY', function() {
-                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategories)
+                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_REPLY, '3', dummyIncidentCategoryKeys)
 
                     expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_REPLY} --> ${ALERT_STATE.WAITING_FOR_CATEGORY}`)
                 })
@@ -97,31 +92,31 @@ describe('alertStateMachine.js unit tests:', function() {
             describe('given alert state is WAITING_FOR_CATEGORY', function() {
                 describe('and messageText contains a valid incident category', function () {
                     it('should transition to WAITING_FOR_DETAILS', function () {
-                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategories)
+                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys)
     
                         expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_DETAILS)
                     })
     
                     it('should change the incident category to the message text', function() {
-                        const { incidentCategory } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategories)
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys)
     
-                        expect(incidentCategory).to.equal('3')
+                        expect(incidentCategoryKey).to.equal('3')
                     })
 
                     it('should change the incident category to the trimmed message text', function() {
-                        const { incidentCategory } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '   2    ', dummyIncidentCategories)
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '   2    ', dummyIncidentCategoryKeys)
     
-                        expect(incidentCategory).to.equal('2')
+                        expect(incidentCategoryKey).to.equal('2')
                     })
     
                     it('should not change the details', function() {
-                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategories)
+                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys)
     
                         expect(details).to.be.undefined
                     })
     
                     it('should give the return message for WAITING_FOR_CATEGORY --> WAITING_FOR_DETAILS', function() {
-                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategories)
+                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '3', dummyIncidentCategoryKeys)
     
                         expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_CATEGORY} --> ${ALERT_STATE.WAITING_FOR_DETAILS}`)
                     })
@@ -129,25 +124,25 @@ describe('alertStateMachine.js unit tests:', function() {
 
                 describe('and messageText does not contain a valid incident category', function() {
                     it('should stay in WAITING_FOR_CATEGORY', function () {
-                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategories)
+                        const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys)
     
                         expect(nextAlertState).to.equal(ALERT_STATE.WAITING_FOR_CATEGORY)
                     })
     
                     it('should not change the incident category', function() {
-                        const { incidentCategory } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '  2A3  ', dummyIncidentCategories)
+                        const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '  2A3  ', dummyIncidentCategoryKeys)
     
-                        expect(incidentCategory).to.be.undefined
+                        expect(incidentCategoryKey).to.be.undefined
                     })
     
                     it('should not change the details', function() {
-                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategories)
+                        const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys)
     
                         expect(details).to.be.undefined
                     })
     
                     it('should give the return message for WAITING_FOR_CATEGORY --> WAITING_FOR_CATEGORY', function() {
-                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategories)
+                        const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_CATEGORY, '5', dummyIncidentCategoryKeys)
     
                         expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_CATEGORY} --> ${ALERT_STATE.WAITING_FOR_CATEGORY}`)
                     })
@@ -156,31 +151,31 @@ describe('alertStateMachine.js unit tests:', function() {
 
             describe('given alert state is WAITING_FOR_DETAILS', function() {
                 it('should transition to COMPLETED', function () {
-                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategories)
+                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys)
 
                     expect(nextAlertState).to.equal(ALERT_STATE.COMPLETED)
                 })
 
                 it('should not change the incident category', function() {
-                    const { incidentCategory } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategories)
+                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys)
 
-                    expect(incidentCategory).to.be.undefined
+                    expect(incidentCategoryKey).to.be.undefined
                 })
 
                 it('should change the details to the message text', function() {
-                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategories)
+                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys)
 
                     expect(details).to.equal('3')
                 })
 
                 it('should change the details to the trimmed message text', function() {
-                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '    many    details    ', dummyIncidentCategories)
+                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '    many    details    ', dummyIncidentCategoryKeys)
 
                     expect(details).to.equal('many    details')
                 })
 
                 it('should give the return message for WAITING_FOR_DETAILS --> COMPLETED', function() {
-                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategories)
+                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.WAITING_FOR_DETAILS, '3', dummyIncidentCategoryKeys)
 
                     expect(returnMessage).to.equal(`${ALERT_STATE.WAITING_FOR_DETAILS} --> ${ALERT_STATE.COMPLETED}`)
                 })
@@ -188,25 +183,25 @@ describe('alertStateMachine.js unit tests:', function() {
 
             describe('given alert state is COMPLETED', function() {
                 it('should stay in COMPLETED', function () {
-                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategories)
+                    const { nextAlertState } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys)
 
                     expect(nextAlertState).to.equal(ALERT_STATE.COMPLETED)
                 })
 
                 it('should not change the incident category', function() {
-                    const { incidentCategory } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategories)
+                    const { incidentCategoryKey } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys)
 
-                    expect(incidentCategory).to.be.undefined
+                    expect(incidentCategoryKey).to.be.undefined
                 })
 
                 it('should not change the details', function() {
-                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategories)
+                    const { details } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys)
 
                     expect(details).to.be.undefined
                 })
 
                 it('should give the return message for COMPLETED --> COMPLETED', function() {
-                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategories)
+                    const { returnMessage } = this.alertStateMachine.processStateTransitionWithMessage(ALERT_STATE.COMPLETED, '3', dummyIncidentCategoryKeys)
 
                     expect(returnMessage).to.equal(`${ALERT_STATE.COMPLETED} --> ${ALERT_STATE.COMPLETED}`)
                 })

--- a/test/unit/testBraveAlerter/testBraveAlerterHandleTwilioRequest.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterHandleTwilioRequest.js
@@ -69,7 +69,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
                     )
                     sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
                         nextAlertState: ALERT_STATE.COMPLETED,
-                        incidentCategory: '2',
+                        incidentCategoryKey: '2',
                         details: 'new details',
                         returnMessage: 'return message',
                     })
@@ -133,7 +133,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
                     )
                     sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
                         nextAlertState: ALERT_STATE.COMPLETED,
-                        incidentCategory: '2',
+                        incidentCategoryKey: '2',
                         details: 'new details',
                         returnMessage: 'return message',
                     })
@@ -183,7 +183,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
                 sinon.stub(this.braveAlerter, 'getAlertSessionByPhoneNumber').returns(null)
                 sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
                     nextAlertState: ALERT_STATE.COMPLETED,
-                    incidentCategory: '2',
+                    incidentCategoryKey: '2',
                     details: 'new details',
                     returnMessage: 'return message',
                 })
@@ -242,7 +242,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
             )
             sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
                 nextAlertState: ALERT_STATE.COMPLETED,
-                incidentCategory: '2',
+                incidentCategoryKey: '2',
                 details: 'new details',
                 returnMessage: 'return message',
             })
@@ -300,7 +300,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
             )
             sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
                 nextAlertState: ALERT_STATE.COMPLETED,
-                incidentCategory: '2',
+                incidentCategoryKey: '2',
                 details: 'new details',
                 returnMessage: 'return message',
             })
@@ -358,7 +358,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
             )
             sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
                 nextAlertState: ALERT_STATE.COMPLETED,
-                incidentCategory: '2',
+                incidentCategoryKey: '2',
                 details: 'new details',
                 returnMessage: 'return message',
             })

--- a/test/unit/testBraveAlerter/testBraveAlerterHandleTwilioRequest.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterHandleTwilioRequest.js
@@ -64,7 +64,8 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
                             'my details', 
                             'my fallback message', 
                             '+11231231234', 
-                            {'3': 'three'}
+                            ['3'],
+                            ['three'],
                         )
                     )
                     sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
@@ -128,7 +129,8 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
                             'my details', 
                             'my fallback message', 
                             '+11231231234', 
-                            {'3': 'three'}
+                            ['3'],
+                            ['three'],
                         )
                     )
                     sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
@@ -237,7 +239,8 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
                     'my details', 
                     'my fallback message', 
                     '+11231231234', 
-                    {'3': 'three'}
+                    ['3'],
+                    ['three'],
                 )
             )
             sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
@@ -295,7 +298,8 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
                     'my details', 
                     'my fallback message', 
                     '+11231231234', 
-                    {'3': 'three'}
+                    ['3'],
+                    ['three'],
                 )
             )
             sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
@@ -353,7 +357,8 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', function() {
                     'my details', 
                     'my fallback message', 
                     '+11231231234', 
-                    {'3': 'three'}
+                    ['3'],
+                    ['three'],
                 )
             )
             sinon.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({

--- a/test/unit/testBraveAlerter/testBraveAlerterSendSingleAlert.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterSendSingleAlert.js
@@ -23,9 +23,7 @@ describe('braveAlerter.js unit tests: sendSingleAlert', function() {
     describe('if successfully sends the alert', function() {
         beforeEach(async function() {
             // Don't actually call Twilio
-            sinon.stub(Twilio, 'sendTwilioMessage').returns({
-                sid: 'my sid'
-            })
+            sinon.stub(Twilio, 'sendTwilioMessage')
 
             const braveAlerter = new BraveAlerter()
 
@@ -38,10 +36,6 @@ describe('braveAlerter.js unit tests: sendSingleAlert', function() {
 
         it('should send alert', function() {
             expect(Twilio.sendTwilioMessage).to.be.calledOnce
-        })
-
-        it('should log the response sid', function() {
-            expect(helpers.log).to.be.calledWith('my sid')
         })
     })
 
@@ -59,7 +53,7 @@ describe('braveAlerter.js unit tests: sendSingleAlert', function() {
             Twilio.sendTwilioMessage.restore()
         })
 
-        it('should log the response sid', function() {
+        it('should log the response error', function() {
             expect(helpers.log).to.be.calledWith('Failed to send single alert: My message')
         })
     })

--- a/test/unit/testBraveAlerter/testBraveAlerterStartAlertSession.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterStartAlertSession.js
@@ -4,6 +4,7 @@ const { afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 const sinonChai = require("sinon-chai");
 
+const ALERT_STATE = require('../../../lib/alertStateEnum.js')
 const BraveAlerter = require('../../../lib/braveAlerter.js')
 const helpers = require('../../../lib/helpers.js')
 const Twilio = require ('../../../lib/twilio.js')
@@ -39,7 +40,7 @@ describe('braveAlerter.js unit tests: startAlertSession unit tests', function() 
             )
             
             await braveAlerter.startAlertSession({
-                alertSession: new AlertSession('guid-123'),
+                sessionId: 'guid-123',
                 toPhoneNumber: '+11231231234',
                 fromPhoneNumber: '+11231231234',
                 reminderMessage: 'My message',
@@ -52,6 +53,14 @@ describe('braveAlerter.js unit tests: startAlertSession unit tests', function() 
 
         it('should send alert', function() {
             expect(Twilio.sendTwilioMessage).to.be.calledOnce
+        })
+
+        it('should call the callback with session ID and alert state STARTED', function() {
+            const expectedAlertSession = new AlertSession(
+                'guid-123',
+                ALERT_STATE.STARTED,
+            )
+            expect(this.fakeAlertSessionChangedCallback).to.be.calledWith(expectedAlertSession)
         })
     })
     


### PR DESCRIPTION
- ODetect's sessions start out with chatbot_state = null. Therefore, when the initial message is sent, it needs to update the chatbot_state to STARTED
- Added `isTestEnvironment` helper method (I don't feel like this is scope creep, but what do you think @schwarrrtz ?)
- Changed the way that I was handling `incidentCategories` to match how PostgreSQL and `ng-pq` handle arrays
- Added a bunch of try/catches
- Updated tests accordingly