### PR TITLE
Add helpers.logError function (CU-jcuw85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `helpers.logError` function that will output to `console.error` with the same format at `helpers.log` (CU-jcuw85).
+
 ### Changed
 
 - Use Brave-wide ESLint and Prettier configuration (CU-eprhhn).

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -36,6 +36,16 @@ function log(logString) {
   }
 }
 
+function logError(logString) {
+  if (isTestEnvironment()) {
+    // Output in colour in test
+    console.error(chalk.dim.cyan(`\t${logString}`)) // eslint-disable-line no-console
+  } else {
+    // Prepend the timestamp in production
+    console.error(`${moment().toISOString()} - ${logString}`) // eslint-disable-line no-console
+  }
+}
+
 function sleep(millis) {
   return new Promise(resolve => setTimeout(resolve, millis))
 }
@@ -45,5 +55,6 @@ module.exports = {
   isTestEnvironment,
   isValidRequest,
   log,
+  logError,
   sleep,
 }


### PR DESCRIPTION
- So that we can have consistent formatting for console.error output. Most importantly, we wanted to have the timestamp

Please let me know what you think of `logError` as the name of the function. I didn't think that just `helpers.error` was descriptive enough.