### PR TITLE
Remove timestamp from helpers.log and helpers.logError (CU-jcuw85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Timestamps from production out and error logs (CU-jcuw85).
+
 ## [2.3.0] - 2021-02-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -195,9 +195,17 @@ Determines whether the given Express request is valid if the given set of proper
 
 **Returns:** `true` if the given request's body contains all of the given properties. `false` otherwise.
 
+### logError(logString)
+
+Logs the given string to stderr as appropriate for the situation.
+
+**logString (string):** The string to log
+
+**Returns:** nothing
+
 ### log(logString)
 
-Logs the given string as appropriate for the situation.
+Logs the given string to stdout as appropriate for the situation.
 
 **logString (string):** The string to log
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,7 +6,6 @@
 
 const chalk = require('chalk')
 const dotenv = require('dotenv')
-const moment = require('moment-timezone')
 
 // Setup environment variables
 dotenv.config()
@@ -32,7 +31,7 @@ function log(logString) {
     console.log(chalk.dim.cyan(`\t${logString}`)) // eslint-disable-line no-console
   } else {
     // Prepend the timestamp in production
-    console.log(`${moment().toISOString()} - ${logString}`) // eslint-disable-line no-console
+    console.log(logString) // eslint-disable-line no-console
   }
 }
 
@@ -42,7 +41,7 @@ function logError(logString) {
     console.error(chalk.dim.cyan(`\t${logString}`)) // eslint-disable-line no-console
   } else {
     // Prepend the timestamp in production
-    console.error(`${moment().toISOString()} - ${logString}`) // eslint-disable-line no-console
+    console.error(logString) // eslint-disable-line no-console
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2528,19 +2528,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.0.tgz",
-      "integrity": "sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA=="
-    },
-    "moment-timezone": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "chalk": "^4.1.0",
     "dotenv": "^7.0.0",
     "express": "^4.17.1",
-    "moment-timezone": "^0.5.31",
     "twilio": "^3.54.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- Timestamps will be added by the runtime environment (pm2 or kubernetes)
- Added missing documentation for helpers.logError to README
- No longer need `moment-timezone`