### PR TITLE
Add POST /alert/designatedevice endpoint (CU-hjwazd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `POST /alert/designatedevice` endpoint (CU-hjwazd).
+
 ## [2.4.0] - 2021-02-23
 
 ### Removed
@@ -73,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GPL 3.0 license.
 - README.
 
-[Unreleased]: https://github.com/bravetechnologycoop/brave-alert-lib/compare/v2.4.0...HEAD
+[unreleased]: https://github.com/bravetechnologycoop/brave-alert-lib/compare/v2.4.0...HEAD
 [2.4.0]: https://github.com/bravetechnologycoop/brave-alert-lib/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/bravetechnologycoop/brave-alert-lib/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/bravetechnologycoop/brave-alert-lib/compare/v2.1.0...v2.2.0

--- a/index.js
+++ b/index.js
@@ -1,11 +1,15 @@
-const alertSession = require('./lib/alertSession')
 const ALERT_STATE = require('./lib/alertStateEnum')
-const braveAlerter = require('./lib/braveAlerter')
+const AlertSession = require('./lib/alertSession')
+const BraveAlerter = require('./lib/braveAlerter')
 const helpers = require('./lib/helpers')
+const Location = require('./lib/location')
+const SYSTEM = require('./lib/systemEnum')
 
 module.exports = {
-  BraveAlerter: braveAlerter,
-  AlertSession: alertSession,
   ALERT_STATE,
+  AlertSession,
+  BraveAlerter,
   helpers,
+  Location,
+  SYSTEM,
 }

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -1,6 +1,7 @@
 const express = require('express')
 const jsonBodyParser = require('body-parser').json()
 const Validator = require('express-validator')
+const WebSocket = require('ws')
 
 const AlertSession = require('./alertSession')
 const ALERT_STATE = require('./alertStateEnum')
@@ -10,10 +11,11 @@ const twilio = require('./twilio')
 
 class BraveAlerter {
   // See README for description of parameters
-  constructor(getAlertSession, getAlertSessionByPhoneNumber, alertSessionChangedCallback, asksIncidentDetails, getReturnMessage) {
+  constructor(getAlertSession, getAlertSessionByPhoneNumber, alertSessionChangedCallback, getLocationData, asksIncidentDetails, getReturnMessage) {
     this.getAlertSession = getAlertSession
     this.getAlertSessionByPhoneNumber = getAlertSessionByPhoneNumber
     this.alertSessionChangedCallback = alertSessionChangedCallback
+    this.getLocationData = getLocationData
 
     this.router = express.Router()
     this.router.post('/alert/sms', jsonBodyParser, this.handleTwilioRequest.bind(this))
@@ -30,6 +32,48 @@ class BraveAlerter {
 
   getRouter() {
     return this.router
+  }
+
+  async authenticate(request, socket, head) {
+    const deviceId = request.header('X-API-Key')
+
+    let location
+    if (deviceId !== undefined) {
+      try {
+        location = await this.getLocationData(deviceId)
+      } catch (err) {
+        helpers.logError(`Failed to get location data for ${deviceId}: ${JSON.stringify(err)}`)
+      }
+    }
+
+    if (deviceId === undefined || location === null) {
+      socket.write('HTTP/1.1 401 Unauthorized')
+      socket.destroy()
+      return
+    }
+
+    this.wss.handleUpgrade(request, socket, head, ws => {
+      this.wss.emit('connection', ws, request)
+    })
+  }
+
+  startWebSockets(server) {
+    this.wss = new WebSocket.Server({ server })
+
+    server.on('upgrade', this.authenticate.bind(this))
+
+    this.wss.on('connection', (ws, request) => {
+      helpers.log(`Connection successful: ${request.header('X-API-KEY')}`)
+
+      ws.on('message', data => {
+        // TODO what to do when I get subsequent messages from the web socket
+        helpers.log(`data from websocket: ${data}`)
+      })
+
+      ws.on('close', () => {
+        // TODO error handling if the socket ever closes (maybe send an alert?)
+      })
+    })
   }
 
   /* eslint-disable class-methods-use-this */

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const jsonBodyParser = require('body-parser').json()
+const Validator = require('express-validator')
 
 const AlertSession = require('./alertSession')
 const ALERT_STATE = require('./alertStateEnum')
@@ -16,6 +17,13 @@ class BraveAlerter {
 
     this.router = express.Router()
     this.router.post('/alert/sms', jsonBodyParser, this.handleTwilioRequest.bind(this))
+    this.router.post(
+      '/alert/designatedevice',
+      jsonBodyParser,
+      Validator.body(['verificationCode']).exists(),
+      Validator.header(['X-API-KEY']).exists(),
+      BraveAlerter.handleDesignateDevice,
+    )
 
     this.alertStateMachine = new AlertStateMachine(asksIncidentDetails, getReturnMessage)
   }
@@ -177,6 +185,21 @@ class BraveAlerter {
     } catch (err) {
       helpers.log(err)
       response.status(500).send()
+    }
+  }
+
+  static handleDesignateDevice(request, response) {
+    const validationErrors = Validator.validationResult(request)
+
+    if (validationErrors.isEmpty()) {
+      const { verificationCode } = request.body
+      const deviceId = request.header('X-API-KEY')
+
+      helpers.log(`************* Verification Code: ${verificationCode} Device ID: ${deviceId}`)
+      response.status(200).send()
+    } else {
+      helpers.log(`Bad request, parameters missing ${JSON.stringify(validationErrors)}`)
+      response.status(400).send()
     }
   }
 }

--- a/lib/location.js
+++ b/lib/location.js
@@ -1,0 +1,9 @@
+class Location {
+  constructor(id, name, system) {
+    this.id = id
+    this.name = name
+    this.system = system
+  }
+}
+
+module.exports = Location

--- a/lib/systemEnum.js
+++ b/lib/systemEnum.js
@@ -1,0 +1,6 @@
+const SYSTEM = {
+  BUTTONS: 'Buttons',
+  SENSOR: 'Sensor',
+}
+
+module.exports = Object.freeze(SYSTEM)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4376,6 +4376,11 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "ws": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
+    },
     "xmlbuilder": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,6 +1607,15 @@
         "vary": "~1.1.2"
       }
     },
+    "express-validator": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.10.0.tgz",
+      "integrity": "sha512-gDtepU94EpUzgFvKO/8JzjZ4uqIF4xHekjYtcNgFDiBK6Hob3MQhPU8s/c3NaWd1xi5e5nA0oVmOJ0b0ZBO36Q==",
+      "requires": {
+        "lodash": "^4.17.20",
+        "validator": "^13.5.2"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4204,6 +4213,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
+      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "chalk": "^4.1.0",
     "dotenv": "^7.0.0",
     "express": "^4.17.1",
+    "express-validator": "^6.10.0",
     "twilio": "^3.54.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "dotenv": "^7.0.0",
     "express": "^4.17.1",
     "express-validator": "^6.10.0",
-    "twilio": "^3.54.2"
+    "twilio": "^3.54.2",
+    "ws": "^7.4.4"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/integration/testBraveAlerter/testBraveAlerterHandleDesignateDevice.js
+++ b/test/integration/testBraveAlerter/testBraveAlerterHandleDesignateDevice.js
@@ -1,0 +1,78 @@
+const expect = require('chai').expect
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const express = require('express')
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+
+const helpers = require('../../../lib/helpers')
+const BraveAlerter = require('../../../lib/braveAlerter')
+
+chai.use(chaiHttp)
+chai.use(sinonChai)
+
+describe('braveAlerter.js integration tests: handleDesignateDevice', () => {
+  beforeEach(() => {
+    this.braveAlerter = new BraveAlerter()
+
+    this.app = express()
+    this.app.use(this.braveAlerter.getRouter())
+
+    sinon.stub(helpers, 'log')
+  })
+
+  afterEach(() => {
+    helpers.log.restore()
+  })
+
+  describe('given valid request parameters', () => {
+    beforeEach(async () => {
+      this.response = await chai
+        .request(this.app)
+        .post('/alert/designatedevice')
+        .set('X-API-KEY', '00000000-000000000000000')
+        .send({ verificationCode: 'ABC123' })
+    })
+
+    it('should log the verification code and device ID', () => {
+      expect(helpers.log).to.be.calledWith('************* Verification Code: ABC123 Device ID: 00000000-000000000000000')
+    })
+
+    it('should return 200', () => {
+      expect(this.response.status).to.equal(200)
+    })
+  })
+
+  describe('given that verificationCode is missing', () => {
+    beforeEach(async () => {
+      this.response = await chai.request(this.app).post('/alert/designatedevice').set('X-API-KEY', '00000000-000000000000000').send({})
+    })
+
+    it('should log the error', () => {
+      expect(helpers.log).to.be.calledWith(
+        'Bad request, parameters missing {"errors":[{"msg":"Invalid value","param":"verificationCode","location":"body"}]}',
+      )
+    })
+
+    it('should return 400', () => {
+      expect(this.response.status).to.equal(400)
+    })
+  })
+
+  describe('given that the API key is missing', () => {
+    beforeEach(async () => {
+      this.response = await chai.request(this.app).post('/alert/designatedevice').send({ verificationCode: 'ABC123' })
+    })
+
+    it('should log the error', () => {
+      expect(helpers.log).to.be.calledWith(
+        'Bad request, parameters missing {"errors":[{"msg":"Invalid value","param":"x-api-key","location":"headers"}]}',
+      )
+    })
+
+    it('should return 400', () => {
+      expect(this.response.status).to.equal(400)
+    })
+  })
+})

--- a/test/integration/testFallbackFlow.js
+++ b/test/integration/testFallbackFlow.js
@@ -26,6 +26,10 @@ function dummyAlertSessionChangedCallback() {
   return 'alertSessionChangedCallback'
 }
 
+function dummyGetLocationData() {
+  return 'getLocationData'
+}
+
 function dummyGetRetunMessages(fromAlertState, toAlertState) {
   return `${fromAlertState} --> ${toAlertState}`
 }
@@ -64,6 +68,7 @@ describe('fallback flow: responder never responds so fallback message is sent to
       dummyGetAlertSession,
       dummyGetAlertSessionByPhoneNumber,
       dummyAlertSessionChangedCallback,
+      dummyGetLocationData,
       true,
       dummyGetRetunMessages,
     )

--- a/test/integration/testHappyPath.js
+++ b/test/integration/testHappyPath.js
@@ -26,6 +26,10 @@ function dummyAlertSessionChangedCallback() {
   return 'alertSessionChangedCallback'
 }
 
+function dummyGetLocationData() {
+  return 'getLocationData'
+}
+
 function dummyGetRetunMessages(fromAlertState, toAlertState) {
   return `${fromAlertState} --> ${toAlertState}`
 }
@@ -68,6 +72,7 @@ describe('happy path integration test: responder responds right away and provide
       dummyGetAlertSession,
       dummyGetAlertSessionByPhoneNumber,
       dummyAlertSessionChangedCallback,
+      dummyGetLocationData,
       true,
       dummyGetRetunMessages,
     )

--- a/test/unit/testBraveAlerter/testBraveAlerterContructor.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterContructor.js
@@ -17,6 +17,10 @@ function dummyAlertSessionChangedCallback() {
   return 'alertSessionChangedCallback'
 }
 
+function dummyGetLocationData() {
+  return 'getLocationData'
+}
+
 function dummyGetReturnMessage() {
   return 'getReturnMessage'
 }
@@ -30,6 +34,7 @@ describe('braveAlerter.js unit tests: constructor', () => {
       dummyGetAlertSession,
       dummyGetAlertSessionByPhoneNumber,
       dummyAlertSessionChangedCallback,
+      dummyGetLocationData,
       true,
       dummyGetReturnMessage,
     )

--- a/test/unit/testBraveAlerter/testBraveAlerterHandleTwilioRequest.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterHandleTwilioRequest.js
@@ -222,7 +222,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
 
   describe('if missing the Body request parameter', () => {
     beforeEach(async () => {
-      const validRequest = {
+      const inValidRequest = {
         body: {
           From: '+11231231234',
           To: '+11231231234',
@@ -249,7 +249,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
       // Don't actually call Twilio
       sinon.stub(Twilio, 'sendTwilioResponse')
 
-      await this.braveAlerter.handleTwilioRequest(validRequest, this.fakeExpressResponse)
+      await this.braveAlerter.handleTwilioRequest(inValidRequest, this.fakeExpressResponse)
     })
 
     afterEach(() => {
@@ -270,7 +270,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
 
   describe('if missing the From request parameter', () => {
     beforeEach(async () => {
-      const validRequest = {
+      const inValidRequest = {
         body: {
           To: '+11231231234',
           Body: 'fake body',
@@ -297,7 +297,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
       // Don't actually call Twilio
       sinon.stub(Twilio, 'sendTwilioResponse')
 
-      await this.braveAlerter.handleTwilioRequest(validRequest, this.fakeExpressResponse)
+      await this.braveAlerter.handleTwilioRequest(inValidRequest, this.fakeExpressResponse)
     })
 
     afterEach(() => {
@@ -318,7 +318,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
 
   describe('if missing the To request parameter', () => {
     beforeEach(async () => {
-      const validRequest = {
+      const inValidRequest = {
         body: {
           From: '+11231231234',
           Body: 'fake body',
@@ -345,7 +345,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
       // Don't actually call Twilio
       sinon.stub(Twilio, 'sendTwilioResponse')
 
-      await this.braveAlerter.handleTwilioRequest(validRequest, this.fakeExpressResponse)
+      await this.braveAlerter.handleTwilioRequest(inValidRequest, this.fakeExpressResponse)
     })
 
     afterEach(() => {


### PR DESCRIPTION
- This endpoint just logs the given device ID and verification code for manual input into the DB
- Updated some variable names in `testBraveAlerterHandleTwilioRequest` to be more accurate
- Use Express Validator to check for valid parameters
- Apparently Express Validator makes it difficult to write unit tests. I couldn't figure out how to stub `Validator.validationResult` and it would always return no errors. So instead of unit testing this function, I did integration tests for it. Which turned out to be a good thing because it helped me find a bug in my code (originally I had `const deviceId = request.headers['X-API-KEY']` but according to the docs, Express always lower-cases their header keys, so they recommend that you use the `request.header()` function instead and then you can put any case that you like and it will figure out what you want. 
- Prettier decided that the "u" in `[unreleased]` should be lowercase. Not sure why, but I tried it on this branch and the link still works.