### PR TITLE
Add ability to send multiple fallback messages (CU-pv8hd5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Alert Sessions expect an array of fallback phone numbers, which will all be messaged simultaneously after the fallback timeout (CU-pv8hd5).
+
 ## [2.4.0] - 2021-02-23
 
 ### Removed
@@ -73,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GPL 3.0 license.
 - README.
 
-[Unreleased]: https://github.com/bravetechnologycoop/brave-alert-lib/compare/v2.4.0...HEAD
+[unreleased]: https://github.com/bravetechnologycoop/brave-alert-lib/compare/v2.4.0...HEAD
 [2.4.0]: https://github.com/bravetechnologycoop/brave-alert-lib/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/bravetechnologycoop/brave-alert-lib/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/bravetechnologycoop/brave-alert-lib/compare/v2.1.0...v2.2.0

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Starts a full alert session configured with the given `alertInfo` object.
 
 **alertInfo.fallbackMessage (string):** Message for the fallback
 
-**alertInfo.fallbackToPhoneNumber (string):** The phone number to send fallback text messages to
+**alertInfo.fallbackToPhoneNumbers (array of strings):** The phone numbers to send fallback text messages to
 
 **alertInfo.fallbackFromPhoneNumber (string):** The phone number to send fallback text messages from
 

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -70,7 +70,7 @@ class BraveAlerter {
 
     if (alertInfo.fallbackTimeoutMillis && alertInfo.fallbackTimeoutMillis > 0) {
       // Set a timer for the fallback
-      setTimeout(this.sendFallbackMessageForSession.bind(this), alertInfo.fallbackTimeoutMillis, alertInfo)
+      setTimeout(this.sendFallbackMessagesForSession.bind(this), alertInfo.fallbackTimeoutMillis, alertInfo)
     }
   }
 
@@ -98,32 +98,32 @@ class BraveAlerter {
     }
   }
 
-  async sendFallbackMessageForSession(alertInfo) {
+  async sendFallbackMessagesForSession(alertInfo) {
     try {
       const alertSession = await this.getAlertSession(alertInfo.sessionId)
 
       if (alertSession.alertState === ALERT_STATE.WAITING_FOR_REPLY) {
-        // Send fallback alert
-        if (alertInfo.fallbackToPhoneNumber && alertInfo.fallbackFromPhoneNumber) {
-          const response = await twilio.sendTwilioMessage(
-            alertInfo.fallbackToPhoneNumber,
-            alertInfo.fallbackFromPhoneNumber,
-            alertInfo.fallbackMessage,
-          )
+        // Send fallback alert(s)
+        if (alertInfo.fallbackToPhoneNumbers && alertInfo.fallbackFromPhoneNumber) {
+          const promises = []
+          alertInfo.fallbackToPhoneNumbers.forEach(fallbackToPhoneNumber => {
+            promises.push(twilio.sendTwilioMessage(fallbackToPhoneNumber, alertInfo.fallbackFromPhoneNumber, alertInfo.fallbackMessage))
+          })
+          const responses = await Promise.all(promises)
 
-          if (response) {
+          if (responses && !responses.every(r => r === undefined)) {
             const changedAlertSession = new AlertSession(alertInfo.sessionId)
-            changedAlertSession.fallbackReturnMessage = response.status
+            changedAlertSession.fallbackReturnMessage = responses.map(r => (r !== undefined ? r.status : 'no_response')).join(', ')
             await this.alertSessionChangedCallback(changedAlertSession)
           } else {
             // TODO Better error handling
-            helpers.log(`Failed to send fallback for session ${alertInfo.sessionId}`)
+            helpers.log(`Failed to send any fallbacks for session ${alertInfo.sessionId}`)
           }
         }
       }
     } catch (err) {
       // TODO Better error handling
-      helpers.log(`Failed to send fallback for session ${alertInfo.sessionId}. ${JSON.stringify(err)}`)
+      helpers.log(`Failed to send any fallbacks for session ${alertInfo.sessionId}. ${JSON.stringify(err)}`)
     }
   }
 

--- a/test/integration/testFallbackFlow.js
+++ b/test/integration/testFallbackFlow.js
@@ -44,11 +44,11 @@ const initialAlertInfo = {
   fallbackTimeoutMillis: 3000, // 3 seconds
   reminderMessage: 'Reminder message',
   fallbackMessage: 'Fallback message',
-  fallbackToPhoneNumber: '+15147332272',
+  fallbackToPhoneNumbers: ['+15147332272', '+15146141784'],
   fallbackFromPhoneNumber: '+15005550006',
 }
 
-describe('fallback flow: responder never responds so fallback message is sent to manager', () => {
+describe('fallback flow: responder never responds so fallback message is sent to manager(s)', () => {
   beforeEach(() => {
     this.currentAlertSession = new AlertSession(
       sessionId,
@@ -97,12 +97,12 @@ describe('fallback flow: responder never responds so fallback message is sent to
 
     this.currentAlertSession.alertState = ALERT_STATE.WAITING_FOR_REPLY
 
-    // Wait for the fallback to send
+    // Wait for the fallbacks to send
     await helpers.sleep(3000)
 
-    // Expect the fallback return message from a successful Twilio request to be 'queued'
+    // Expect the fallback return messages from a successful Twilio request to be 'queued' for each phone number
     expect(this.braveAlerter.alertSessionChangedCallback.getCall(2).args[0]).to.eql(
-      new AlertSession(sessionId, undefined, undefined, undefined, 'queued'),
+      new AlertSession(sessionId, undefined, undefined, undefined, 'queued, queued'),
     )
   })
 })

--- a/test/integration/testHappyPath.js
+++ b/test/integration/testHappyPath.js
@@ -46,7 +46,7 @@ const initialAlertInfo = {
   fallbackTimeoutMillis: 5 * 60 * 1000, // 5 minutes
   reminderMessage: 'Reminder message',
   fallbackMessage: 'Fallback message',
-  fallbackToPhoneNumber: '+17778889999',
+  fallbackToPhoneNumbers: ['+17778889999'],
   fallbackFromPhoneNumber: '+13336669999',
 }
 

--- a/test/unit/testBraveAlerter/testBraveAlerterStartAlertSession.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterStartAlertSession.js
@@ -202,11 +202,11 @@ describe('braveAlerter.js unit tests: startAlertSession unit tests', () => {
       this.clock = sinon.useFakeTimers()
 
       this.braveAlerter = new BraveAlerter()
-      sinon.stub(this.braveAlerter, 'sendFallbackMessageForSession')
+      sinon.stub(this.braveAlerter, 'sendFallbackMessagesForSession')
     })
 
     afterEach(() => {
-      this.braveAlerter.sendFallbackMessageForSession.restore()
+      this.braveAlerter.sendFallbackMessagesForSession.restore()
 
       this.clock.restore()
     })
@@ -218,7 +218,7 @@ describe('braveAlerter.js unit tests: startAlertSession unit tests', () => {
       })
       this.clock.tick(2)
 
-      expect(this.braveAlerter.sendFallbackMessageForSession).to.be.calledOnce
+      expect(this.braveAlerter.sendFallbackMessagesForSession).to.be.calledOnce
     })
 
     it('negative should not send a fallback alert', async () => {
@@ -228,7 +228,7 @@ describe('braveAlerter.js unit tests: startAlertSession unit tests', () => {
       })
       this.clock.tick(2)
 
-      expect(this.braveAlerter.sendFallbackMessageForSession).not.to.be.called
+      expect(this.braveAlerter.sendFallbackMessagesForSession).not.to.be.called
     })
 
     it('not given should not send a fallback alert', async () => {
@@ -237,7 +237,7 @@ describe('braveAlerter.js unit tests: startAlertSession unit tests', () => {
       })
       this.clock.tick(2)
 
-      expect(this.braveAlerter.sendFallbackMessageForSession).not.to.be.called
+      expect(this.braveAlerter.sendFallbackMessagesForSession).not.to.be.called
     })
   })
 })


### PR DESCRIPTION
- Changed the fallbackToPhoneNumber parameter to an array of strings
  instead of a string. It will attempt to send the fallback message
  to all of these numbers simultaneously.
- The resulting fallbackReturnMessage will be a comma-separated string of the return values from Twilio. If a particular phone number doesn't send correctly, its value in the comma-separated string will be "no_response"
- Updated tests accordingly