### PR TITLE
added GET /alert/newNotificationsCount endpoint (CU-hjwcwk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `GET /alert/newNotificationsCount` endpoint (CU-hjwcwk).
+
 ## [3.4.0] - 2021-06-24
 
 ### Added

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -12,12 +12,13 @@ const { handleDesignateDevice } = require('./designateDevice')
 class BraveAlerter {
   // See README for description of parameters
   // eslint-disable-next-line prettier/prettier
-  constructor(getAlertSession, getAlertSessionByPhoneNumber, alertSessionChangedCallback, getLocationByAlertApiKey, getHistoricAlertsByAlertApiKey, asksIncidentDetails, getReturnMessage) {
+  constructor(getAlertSession, getAlertSessionByPhoneNumber, alertSessionChangedCallback, getLocationByAlertApiKey, getHistoricAlertsByAlertApiKey, getNewNotificationsCountByAlertApiKey, asksIncidentDetails, getReturnMessage) {
     this.getAlertSession = getAlertSession
     this.getAlertSessionByPhoneNumber = getAlertSessionByPhoneNumber
     this.alertSessionChangedCallback = alertSessionChangedCallback
     this.getLocationByAlertApiKey = getLocationByAlertApiKey
     this.getHistoricAlertsByAlertApiKey = getHistoricAlertsByAlertApiKey
+    this.getNewNotificationsCountByAlertApiKey = getNewNotificationsCountByAlertApiKey
 
     this.router = express.Router()
     this.router.post('/alert/sms', jsonBodyParser, this.handleTwilioRequest.bind(this))
@@ -35,6 +36,7 @@ class BraveAlerter {
       Validator.query(['maxHistoricAlerts']).isInt({ min: 0 }),
       this.handleGetHistoricAlerts.bind(this),
     )
+    this.router.get('/alert/newNotificationsCount', Validator.header(['X-API-KEY']).notEmpty(), this.handleGetNewNotificationsCount.bind(this))
 
     this.alertStateMachine = new AlertStateMachine(asksIncidentDetails, getReturnMessage)
   }
@@ -234,6 +236,20 @@ class BraveAlerter {
       }
 
       response.status(200).json(JSON.stringify(historicAlerts))
+    } else {
+      const errorMessage = `Bad request to ${request.path}: ${validationErrors.array()}`
+      helpers.logError(errorMessage)
+      response.status(400).send(errorMessage)
+    }
+  }
+
+  async handleGetNewNotificationsCount(request, response) {
+    const validationErrors = Validator.validationResult(request).formatWith(helpers.formatExpressValidationErrors)
+
+    if (validationErrors.isEmpty()) {
+      const alertApiKey = request.header('X-API-KEY')
+      const newNotificationsCount = await this.getNewNotificationsCountByAlertApiKey(alertApiKey)
+      response.status(200).json(JSON.stringify(newNotificationsCount))
     } else {
       const errorMessage = `Bad request to ${request.path}: ${validationErrors.array()}`
       helpers.logError(errorMessage)

--- a/test/integration/testBraveAlerter/testBraveAlerterHandleGetNewNotificationsCount.js
+++ b/test/integration/testBraveAlerter/testBraveAlerterHandleGetNewNotificationsCount.js
@@ -1,0 +1,104 @@
+// Third-party dependencies
+const { expect } = require('chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const express = require('express')
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+
+// In-house dependencies
+const helpers = require('../../../lib/helpers')
+const BraveAlerter = require('../../../lib/braveAlerter')
+
+chai.use(chaiHttp)
+chai.use(sinonChai)
+
+describe('braveAlerter.js integration tests: handleGetNewNotificationsCount', () => {
+  beforeEach(() => {
+    sinon.spy(helpers, 'logError')
+  })
+
+  afterEach(() => {
+    helpers.logError.restore()
+  })
+
+  describe('given valid request parameters and API key', () => {
+    beforeEach(async () => {
+      this.fakeNewNotificationsCount = 4
+
+      const braveAlerter = new BraveAlerter(null, null, null, null, null, () => {
+        return this.fakeNewNotificationsCount
+      })
+
+      const app = express()
+      app.use(braveAlerter.getRouter())
+
+      // eslint-disable-next-line prettier/prettier
+      this.response = await chai
+        .request(app)
+        .get('/alert/newNotificationsCount')
+        .set('X-API-KEY', '00000000-000000000000000')
+        .send({})
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should return a JSON response body', async () => {
+      expect(this.response.body).to.equal(JSON.stringify(this.fakeNewNotificationsCount))
+    })
+  })
+
+  describe('given that the API key is blank', () => {
+    beforeEach(async () => {
+      const braveAlerter = new BraveAlerter(null, null, null, null, null, () => {
+        return 5
+      })
+
+      const app = express()
+      app.use(braveAlerter.getRouter())
+
+      // eslint-disable-next-line prettier/prettier
+      this.response = await chai
+        .request(app)
+        .get('/alert/newNotificationsCount')
+        .set('X-API-KEY', '')
+        .send({})
+    })
+
+    it('should log the error', () => {
+      expect(helpers.logError).to.be.calledWith('Bad request to /alert/newNotificationsCount: x-api-key (Invalid value)')
+    })
+
+    it('should return 400', () => {
+      expect(this.response.status).to.equal(400)
+    })
+  })
+
+  describe('given that the API key is missing', () => {
+    beforeEach(async () => {
+      const braveAlerter = new BraveAlerter(null, null, null, null, null, () => {
+        return 6
+      })
+
+      const app = express()
+      app.use(braveAlerter.getRouter())
+
+      // eslint-disable-next-line prettier/prettier
+      this.response = await chai
+        .request(app)
+        .get('/alert/newNotificationsCount')
+        .send({})
+    })
+
+    it('should log the error', () => {
+      expect(helpers.logError).to.be.calledWith('Bad request to /alert/newNotificationsCount: x-api-key (Invalid value)')
+    })
+
+    it('should return 400', () => {
+      expect(this.response.status).to.equal(400)
+    })
+  })
+})

--- a/test/integration/testHappyPath.js
+++ b/test/integration/testHappyPath.js
@@ -34,6 +34,10 @@ function dummyGetHistoricAlertsByAlertApiKey() {
   return 'getHistoricAlertsByAlertApiKey'
 }
 
+function dummyGetNewNotificationsCountByAlertApiKey() {
+  return 'getNewNotificationsCountByAlertApiKey'
+}
+
 function dummyGetRetunMessages(fromAlertState, toAlertState) {
   return `${fromAlertState} --> ${toAlertState}`
 }
@@ -78,6 +82,7 @@ describe('happy path integration test: responder responds right away and provide
       dummyAlertSessionChangedCallback,
       dummyGetLocationByAlertApiKey,
       dummyGetHistoricAlertsByAlertApiKey,
+      dummyGetNewNotificationsCountByAlertApiKey,
       true,
       dummyGetRetunMessages,
     )

--- a/test/unit/testBraveAlerter/testBraveAlerterContructor.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterContructor.js
@@ -25,6 +25,10 @@ function dummyGetHistoricAlertsByAlertApiKey() {
   return 'getHistoricAlertsByAlertApiKey'
 }
 
+function dummyGetNewNotificationsCountByAlertApiKey() {
+  return 'getNewNotificationsCountByAlertApiKey'
+}
+
 function dummyGetReturnMessage() {
   return 'getReturnMessage'
 }
@@ -40,6 +44,7 @@ describe('braveAlerter.js unit tests: constructor', () => {
       dummyAlertSessionChangedCallback,
       dummyGetLocationByAlertApiKey,
       dummyGetHistoricAlertsByAlertApiKey,
+      dummyGetNewNotificationsCountByAlertApiKey,
       true,
       dummyGetReturnMessage,
     )


### PR DESCRIPTION
- added `GET /alert/newNotificationsCount` endpoint to be used by the Alert App
- added and updated tests

I tested this by deploying it to the Buttons dev server and hitting the endpoint with my WIP Alert App code - the number of new notifications renders in the app as expected. I also added integration tests, which pass as expected.