### PR TITLE
Add audit-ci to Travis to perform static security checks (CU-121j1qz)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ env:
     # TWILIO_TOKEN_TEST (from https://www.twilio.com/console/voice/project/test-credentials)
     - secure: 'FPm3qiQofYifPEXpfNEW9ETnU2zASy8l8H63Pt3DurMiuBHJpVJoKXbJeh8OE9UvVnEpZ9yYGkfWxoAQBywcoVEKfdhWgPzlvdBKEH5/Iz8EzGEBst1M1l3OGex/GZYsb8T43ldsdlcE5vLiMLNX8qv6fW/Ye0O66vKE7tebiGvDPXnyXgbCofXPBg5oES37n3E4mQapqas2RGucElQocDmk4BjqUw8KhwU2RzVRhg6qxDqHx116VEm9IsnpwqWl0YwoYzzzkY7jxrE/aCYkwJkufEdS9CxIt9ZXn+WSHBJncPL5HGxjJAwHE5CgPZDZe4ejpYmHW0DBRNGp5Qs6rXU9jVW85DDh582RNryuoqkNH4MGgVYXsesHzFcxlDbJ7VRH4l0GibWAVw4Lq5xoKiiiqW67felfglCENDdngnq8TM5KN8Nw7kDE2hH2yjbMiz3noBKwSIvoNCGJTsM+cKCnt5yCfSe1fgCzJPa8KO18plT6HRUw+dmDXF/yrquIi95UCB/wn4Y+TAosNbJoUE0RARhZNpJe7phDdoMXJI0CGNhzxcLiw3MHSpER1q42j777we2plLlVatbQvf44sVDvRap3J6fsHvfYEcJtgVPrB0LciZqizRIqe/NXunKTO0RRoTz6/QU2yaUmmBebthRuIG2rwb3q1jBFzHthI9w='
 
-# run unit tests
+# Run security audit, linting, unit tests, and integration tests
 script:
+  - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npx audit-ci --config ./audit-ci.json; fi
   - npm run lint
   - sudo env "PATH=$PATH" npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Security audit to Travis (CU-121j1qz).
+
+### Security
+
+- Updated dependencies (CU-121j1qz).
+
 ## [3.5.0] - 2021-07-09
 
 ### Added

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,0 +1,4 @@
+{
+  "high": true,
+  "allowlist": []
+}


### PR DESCRIPTION
- This will block the build when there are high or critical security
  issues. The build will only pass if these issues are added to the
  allowlist in audit-ci.json or fixed.

## Test Plan:
- :heavy_check_mark: With no changes in the project
   - :heavy_check_mark: See in the Travis logs that it ran (https://app.travis-ci.com/github/bravetechnologycoop/brave-alert-lib/builds/232985360)
   - :heavy_check_mark: Travis passes
- :heavy_check_mark:  Add a known high severity security issue to the project 
   - :heavy_check_mark: See in the Travis logs that it ran (https://app.travis-ci.com/github/bravetechnologycoop/brave-alert-lib/builds/232985564)
   - :heavy_check_mark:  Travis fails