### PR TITLE
Fix JSON return values for designateDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Changed the return values to be more consistent across all the endpoints.
+
 ### Fixed
 
 - Designate Device response now returns JSON.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Designate Device response now returns JSON.
+
 ## [5.0.0] - 2021-09-27
 
 ### Added

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -292,9 +292,9 @@ class BraveAlerter {
 
       const location = await this.getLocationByAlertApiKey(alertApiKey)
       if (location) {
-        response.status(200).json(JSON.stringify(location))
+        response.status(200).json(location)
       } else {
-        response.status(200).json(JSON.stringify({}))
+        response.status(200).json({})
       }
     } else {
       const errorMessage = `Bad request to ${request.path}: ${validationErrors.array()}`
@@ -317,7 +317,7 @@ class BraveAlerter {
         return
       }
 
-      response.status(200).json(JSON.stringify(activeAlerts))
+      response.status(200).json(activeAlerts)
     } else {
       const errorMessage = `Bad request to ${request.path}: ${validationErrors.array()}`
       helpers.logError(errorMessage)
@@ -340,7 +340,7 @@ class BraveAlerter {
         return
       }
 
-      response.status(200).json(JSON.stringify(historicAlerts))
+      response.status(200).json(historicAlerts)
     } else {
       const errorMessage = `Bad request to ${request.path}: ${validationErrors.array()}`
       helpers.logError(errorMessage)
@@ -354,7 +354,7 @@ class BraveAlerter {
     if (validationErrors.isEmpty()) {
       const alertApiKey = request.header('X-API-KEY')
       const newNotificationsCount = await this.getNewNotificationsCountByAlertApiKey(alertApiKey)
-      response.status(200).json(JSON.stringify(newNotificationsCount))
+      response.status(200).json(newNotificationsCount)
     } else {
       const errorMessage = `Bad request to ${request.path}: ${validationErrors.array()}`
       helpers.logError(errorMessage)
@@ -396,9 +396,9 @@ class BraveAlerter {
 
       const activeAlerts = await this.getActiveAlertsByAlertApiKey(alertApiKey)
       if (activeAlerts) {
-        response.status(200).json(JSON.stringify(activeAlerts))
+        response.status(200).json(activeAlerts)
       } else {
-        response.status(200).json(JSON.stringify({}))
+        response.status(200).json({})
       }
     } catch (err) {
       const errorMessage = `Failed to acknowledge alert for session ${sessionId}: ${err.toString()}`
@@ -441,9 +441,9 @@ class BraveAlerter {
 
       const activeAlerts = await this.getActiveAlertsByAlertApiKey(alertApiKey)
       if (activeAlerts) {
-        response.status(200).json(JSON.stringify(activeAlerts))
+        response.status(200).json(activeAlerts)
       } else {
-        response.status(200).json(JSON.stringify({}))
+        response.status(200).json({})
       }
     } catch (err) {
       const errorMessage = `Failed to respond to alert for session ${sessionId}: ${err.toString()}`
@@ -493,9 +493,9 @@ class BraveAlerter {
 
       const activeAlerts = await this.getActiveAlertsByAlertApiKey(alertApiKey)
       if (activeAlerts) {
-        response.status(200).json(JSON.stringify(activeAlerts))
+        response.status(200).json(activeAlerts)
       } else {
-        response.status(200).json(JSON.stringify({}))
+        response.status(200).json({})
       }
     } catch (err) {
       const errorMessage = `Failed to record incident category ${incidentCategory} for session ${sessionId}: ${err.toString()}`

--- a/lib/designateDevice.js
+++ b/lib/designateDevice.js
@@ -10,11 +10,11 @@ function handleDesignateDevice(request, response) {
     const alertApiKey = request.header('X-API-KEY')
 
     helpers.log(`************* Verification Code: ${verificationCode} Alert API Key: ${alertApiKey} Responder Push ID: ${responderPushId}`)
-    response.status(200).json(JSON.stringify('OK'))
+    response.status(200).json('OK')
   } else {
     const errorMessage = `Bad request to ${request.path}: ${validationErrors.array()}`
     helpers.logError(errorMessage)
-    response.status(400).send(errorMessage)
+    response.status(400).json(errorMessage)
   }
 }
 

--- a/test/integration/testBraveAlerter/testBraveAlerterHandleAcknowledgeAlertSession.js
+++ b/test/integration/testBraveAlerter/testBraveAlerterHandleAcknowledgeAlertSession.js
@@ -69,11 +69,15 @@ describe('braveAlerter.js integration tests: handleAcknowledgeAlertSession', () 
     })
 
     it('should return the active alerts', () => {
-      expect(JSON.parse(this.response.body)).to.eql(this.activeAlerts)
+      expect(this.response.body).to.eql(this.activeAlerts)
     })
 
     it('should return 200', () => {
       expect(this.response.status).to.equal(200)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -99,6 +103,10 @@ describe('braveAlerter.js integration tests: handleAcknowledgeAlertSession', () 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that sessionId is blank', () => {
@@ -121,6 +129,10 @@ describe('braveAlerter.js integration tests: handleAcknowledgeAlertSession', () 
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -145,6 +157,10 @@ describe('braveAlerter.js integration tests: handleAcknowledgeAlertSession', () 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that the API key is blank', () => {
@@ -168,6 +184,10 @@ describe('braveAlerter.js integration tests: handleAcknowledgeAlertSession', () 
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 })

--- a/test/integration/testBraveAlerter/testBraveAlerterHandleGetActiveAlerts.js
+++ b/test/integration/testBraveAlerter/testBraveAlerterHandleGetActiveAlerts.js
@@ -62,8 +62,12 @@ describe('braveAlerter.js integration tests: handleGetActiveAlerts', () => {
       expect(this.response).to.have.status(200)
     })
 
-    it('should return a JSON response body', async () => {
-      expect(JSON.parse(this.response.body)).to.eql(this.fakeActiveAlerts)
+    it('should return the active alerts', async () => {
+      expect(this.response.body).to.eql(this.fakeActiveAlerts)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -90,8 +94,12 @@ describe('braveAlerter.js integration tests: handleGetActiveAlerts', () => {
       expect(this.response).to.have.status(200)
     })
 
-    it('should return a JSON response body', async () => {
-      expect(JSON.parse(this.response.body)).to.eql([])
+    it('should return no active alerts', async () => {
+      expect(this.response.body).to.eql([])
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -117,6 +125,10 @@ describe('braveAlerter.js integration tests: handleGetActiveAlerts', () => {
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that the API key is missing', () => {
@@ -139,6 +151,10 @@ describe('braveAlerter.js integration tests: handleGetActiveAlerts', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -167,6 +183,10 @@ describe('braveAlerter.js integration tests: handleGetActiveAlerts', () => {
 
     it('should return 500', () => {
       expect(this.response.status).to.equal(500)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 })

--- a/test/integration/testBraveAlerter/testBraveAlerterHandleGetHistoricAlerts.js
+++ b/test/integration/testBraveAlerter/testBraveAlerterHandleGetHistoricAlerts.js
@@ -28,8 +28,24 @@ describe('braveAlerter.js integration tests: handleGetHistoricAlerts', () => {
   describe('given valid request parameters and historicAlerts that corresponds to the API key', () => {
     beforeEach(async () => {
       this.fakeHistoricAlerts = [
-        new HistoricAlert('fakeId', 'fakeDeviceName', 'fakeCategory', ALERT_TYPE.BUTTONS_URGENT, 4, '2021-01-05T15:22:30.000Z'),
-        new HistoricAlert('fakeId2', 'fakeDeviceName2', 'fakeCategory2', ALERT_TYPE.BUTTONS_NOT_URGENT, 4, '2021-01-06T15:22:30.000Z'),
+        new HistoricAlert(
+          'fakeId',
+          'fakeDeviceName',
+          'fakeCategory',
+          ALERT_TYPE.BUTTONS_URGENT,
+          4,
+          '2021-01-05T15:22:30.000Z',
+          '2021-01-05T15:25:00.000Z',
+        ),
+        new HistoricAlert(
+          'fakeId2',
+          'fakeDeviceName2',
+          'fakeCategory2',
+          ALERT_TYPE.BUTTONS_NOT_URGENT,
+          4,
+          '2021-01-06T15:22:30.000Z',
+          '2021-01-05T15:25:00.000Z',
+        ),
       ]
 
       const braveAlerter = testingHelpers.braveAlerterFactory({
@@ -54,8 +70,12 @@ describe('braveAlerter.js integration tests: handleGetHistoricAlerts', () => {
       expect(this.response).to.have.status(200)
     })
 
-    it('should return a JSON response body', async () => {
-      expect(this.response.body).to.equal(JSON.stringify(this.fakeHistoricAlerts))
+    it('should return the historic alerts', async () => {
+      expect(this.response.body).to.eql(this.fakeHistoricAlerts)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -83,8 +103,12 @@ describe('braveAlerter.js integration tests: handleGetHistoricAlerts', () => {
       expect(this.response).to.have.status(200)
     })
 
-    it('should return a JSON response body', async () => {
-      expect(this.response.body).to.equal('[]')
+    it('should return no historic alerts', async () => {
+      expect(this.response.body).to.eql([])
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -111,6 +135,10 @@ describe('braveAlerter.js integration tests: handleGetHistoricAlerts', () => {
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that the API key is missing', () => {
@@ -134,6 +162,10 @@ describe('braveAlerter.js integration tests: handleGetHistoricAlerts', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -159,6 +191,10 @@ describe('braveAlerter.js integration tests: handleGetHistoricAlerts', () => {
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that maxHistoricAlerts is missing', () => {
@@ -182,6 +218,10 @@ describe('braveAlerter.js integration tests: handleGetHistoricAlerts', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -207,6 +247,10 @@ describe('braveAlerter.js integration tests: handleGetHistoricAlerts', () => {
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that maxHistoricAlerts is less than 0', () => {
@@ -230,6 +274,10 @@ describe('braveAlerter.js integration tests: handleGetHistoricAlerts', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -258,6 +306,10 @@ describe('braveAlerter.js integration tests: handleGetHistoricAlerts', () => {
 
     it('should return 500', () => {
       expect(this.response.status).to.equal(500)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 })

--- a/test/integration/testBraveAlerter/testBraveAlerterHandleGetLocation.js
+++ b/test/integration/testBraveAlerter/testBraveAlerterHandleGetLocation.js
@@ -45,8 +45,12 @@ describe('braveAlerter.js integration tests: handleGetLocation', () => {
       expect(this.response).to.have.status(200)
     })
 
-    it('should return a JSON response body', async () => {
-      expect(this.response.body).to.equal(JSON.stringify(this.fakeLocation))
+    it('should return the location', async () => {
+      expect(this.response.body).to.eql(this.fakeLocation)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -68,8 +72,12 @@ describe('braveAlerter.js integration tests: handleGetLocation', () => {
       expect(this.response).to.have.status(200)
     })
 
-    it('should return a JSON response body', async () => {
-      expect(this.response.body).to.equal('{}')
+    it('should return no location', async () => {
+      expect(this.response.body).to.eql({})
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -90,6 +98,10 @@ describe('braveAlerter.js integration tests: handleGetLocation', () => {
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that the API key is missing', () => {
@@ -108,6 +120,10 @@ describe('braveAlerter.js integration tests: handleGetLocation', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 })

--- a/test/integration/testBraveAlerter/testBraveAlerterHandleGetNewNotificationsCount.js
+++ b/test/integration/testBraveAlerter/testBraveAlerterHandleGetNewNotificationsCount.js
@@ -44,8 +44,12 @@ describe('braveAlerter.js integration tests: handleGetNewNotificationsCount', ()
       expect(this.response).to.have.status(200)
     })
 
-    it('should return a JSON response body', async () => {
-      expect(this.response.body).to.equal(JSON.stringify(this.fakeNewNotificationsCount))
+    it('should return the notification count', async () => {
+      expect(this.response.body).to.equal(this.fakeNewNotificationsCount)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -67,6 +71,10 @@ describe('braveAlerter.js integration tests: handleGetNewNotificationsCount', ()
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that the API key is missing', () => {
@@ -86,6 +94,10 @@ describe('braveAlerter.js integration tests: handleGetNewNotificationsCount', ()
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 })

--- a/test/integration/testBraveAlerter/testBraveAlerterHandleIncidentCategory.js
+++ b/test/integration/testBraveAlerter/testBraveAlerterHandleIncidentCategory.js
@@ -71,12 +71,16 @@ describe('braveAlerter.js integration tests: handleIncidentCategory', () => {
       expect(helpers.logError).not.to.be.called
     })
 
-    it('should return the active alerts', () => {
-      expect(JSON.parse(this.response.body)).to.eql(this.activeAlerts)
+    it('should return the active alert', () => {
+      expect(this.response.body).to.eql(this.activeAlerts)
     })
 
     it('should return 200', () => {
       expect(this.response.status).to.equal(200)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -102,6 +106,10 @@ describe('braveAlerter.js integration tests: handleIncidentCategory', () => {
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that sessionId is blank', () => {
@@ -124,6 +132,10 @@ describe('braveAlerter.js integration tests: handleIncidentCategory', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -149,6 +161,10 @@ describe('braveAlerter.js integration tests: handleIncidentCategory', () => {
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that sessionId is blank', () => {
@@ -171,6 +187,10 @@ describe('braveAlerter.js integration tests: handleIncidentCategory', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -195,6 +215,10 @@ describe('braveAlerter.js integration tests: handleIncidentCategory', () => {
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that the API key is blank', () => {
@@ -218,6 +242,10 @@ describe('braveAlerter.js integration tests: handleIncidentCategory', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 })

--- a/test/integration/testBraveAlerter/testBraveAlerterHandleRespondToAlertSession.js
+++ b/test/integration/testBraveAlerter/testBraveAlerterHandleRespondToAlertSession.js
@@ -69,11 +69,15 @@ describe('braveAlerter.js integration tests: handleRespondToAlertSession', () =>
     })
 
     it('should return the active alerts', () => {
-      expect(JSON.parse(this.response.body)).to.eql(this.activeAlerts)
+      expect(this.response.body).to.eql(this.activeAlerts)
     })
 
     it('should return 200', () => {
       expect(this.response.status).to.equal(200)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -99,6 +103,10 @@ describe('braveAlerter.js integration tests: handleRespondToAlertSession', () =>
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that sessionId is blank', () => {
@@ -121,6 +129,10 @@ describe('braveAlerter.js integration tests: handleRespondToAlertSession', () =>
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -145,6 +157,10 @@ describe('braveAlerter.js integration tests: handleRespondToAlertSession', () =>
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that the API key is blank', () => {
@@ -168,6 +184,10 @@ describe('braveAlerter.js integration tests: handleRespondToAlertSession', () =>
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 })

--- a/test/integration/testDesignateDevice.js
+++ b/test/integration/testDesignateDevice.js
@@ -46,6 +46,10 @@ describe('designateDevice.js integration tests: handleDesignateDevice', () => {
     it('should return 200', () => {
       expect(this.response.status).to.equal(200)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that verificationCode is missing', () => {
@@ -63,6 +67,10 @@ describe('designateDevice.js integration tests: handleDesignateDevice', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -82,6 +90,10 @@ describe('designateDevice.js integration tests: handleDesignateDevice', () => {
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that responderPushId is missing', () => {
@@ -99,6 +111,10 @@ describe('designateDevice.js integration tests: handleDesignateDevice', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -118,6 +134,10 @@ describe('designateDevice.js integration tests: handleDesignateDevice', () => {
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
     })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
+    })
   })
 
   describe('given that the API key is missing', () => {
@@ -131,6 +151,10 @@ describe('designateDevice.js integration tests: handleDesignateDevice', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 
@@ -149,6 +173,10 @@ describe('designateDevice.js integration tests: handleDesignateDevice', () => {
 
     it('should return 400', () => {
       expect(this.response.status).to.equal(400)
+    })
+
+    it('should return json', () => {
+      expect(this.response).to.be.json
     })
   })
 })

--- a/test/integration/testDesignateDevice.js
+++ b/test/integration/testDesignateDevice.js
@@ -1,4 +1,4 @@
-const { expect, assert } = require('chai')
+const { expect } = require('chai')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
@@ -41,14 +41,6 @@ describe('designateDevice.js integration tests: handleDesignateDevice', () => {
       expect(helpers.log).to.be.calledWith(
         '************* Verification Code: ABC123 Alert API Key: 00000000-000000000000000 Responder Push ID: pushID',
       )
-    })
-
-    it('should return a JSON response body', async () => {
-      try {
-        JSON.parse(this.response.body)
-      } catch (e) {
-        assert.fail('Getting the JSON string should not throw an error. Make sure that your response is sent with ".json(JSON.stringify(...))"')
-      }
     })
 
     it('should return 200', () => {

--- a/test/unit/testBraveAlerter/testBraveAlerterHandleAcknowledgeAlertSession.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterHandleAcknowledgeAlertSession.js
@@ -70,8 +70,8 @@ describe('braveAlerter.js unit tests: handleAcknowledgeAlertSession', () => {
           expect(this.braveAlerter.alertSessionChangedCallback).to.be.calledWith(new AlertSession(this.goodSessionId, CHATBOT_STATE.RESPONDING))
         })
 
-        it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+        it('should return the active alerts as JSON', () => {
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -120,8 +120,8 @@ describe('braveAlerter.js unit tests: handleAcknowledgeAlertSession', () => {
           expect(this.braveAlerter.alertSessionChangedCallback).to.be.calledWith(new AlertSession(this.goodSessionId, CHATBOT_STATE.RESPONDING))
         })
 
-        it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+        it('should return the active alerts as JSON', () => {
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -176,8 +176,8 @@ describe('braveAlerter.js unit tests: handleAcknowledgeAlertSession', () => {
           expect(this.braveAlerter.alertSessionChangedCallback).not.to.be.called
         })
 
-        it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+        it('should return the active alerts as JSON', () => {
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -232,8 +232,8 @@ describe('braveAlerter.js unit tests: handleAcknowledgeAlertSession', () => {
           expect(this.braveAlerter.alertSessionChangedCallback).not.to.be.called
         })
 
-        it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+        it('should return the active alerts as JSON', () => {
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -288,8 +288,8 @@ describe('braveAlerter.js unit tests: handleAcknowledgeAlertSession', () => {
           expect(this.braveAlerter.alertSessionChangedCallback).not.to.be.called
         })
 
-        it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+        it('should return the active alerts as JSON', () => {
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -344,8 +344,8 @@ describe('braveAlerter.js unit tests: handleAcknowledgeAlertSession', () => {
           expect(this.braveAlerter.alertSessionChangedCallback).not.to.be.called
         })
 
-        it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+        it('should return the active alerts as JSON', () => {
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -380,6 +380,12 @@ describe('braveAlerter.js unit tests: handleAcknowledgeAlertSession', () => {
 
       it('should log the failure', () => {
         expect(helpers.logError).to.be.calledWith(`Failed to acknowledge alert for session ${this.badSessionId}: No corresponding session`)
+      })
+
+      it('should return the error message as JSON', () => {
+        expect(this.fakeExpressResponse.json).to.be.calledWith(
+          `Failed to acknowledge alert for session ${this.badSessionId}: No corresponding session`,
+        )
       })
 
       it('should not call alertSessionChangedCallback', () => {

--- a/test/unit/testBraveAlerter/testBraveAlerterHandleIncidentCategory.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterHandleIncidentCategory.js
@@ -75,8 +75,8 @@ describe('braveAlerter.js unit tests: handleIncidentCategory', () => {
             expect(this.braveAlerter.alertSessionChangedCallback).to.be.calledWith(new AlertSession(this.goodSessionId, CHATBOT_STATE.COMPLETED, '1'))
           })
 
-          it('should return the active alerts', () => {
-            expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+          it('should return the active alerts as JSON', () => {
+            expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
           })
 
           it('should return 200', () => {
@@ -116,6 +116,12 @@ describe('braveAlerter.js unit tests: handleIncidentCategory', () => {
 
           it('should log the failure', () => {
             expect(helpers.logError).to.be.calledWith(
+              `Failed to record incident category ${this.incidentCategory} for session ${this.goodSessionId}: Session is not waiting for incident category (current state: ${CHATBOT_STATE.COMPLETED})`,
+            )
+          })
+
+          it('should return the error message as JSON', () => {
+            expect(this.fakeExpressResponse.json).to.be.calledWith(
               `Failed to record incident category ${this.incidentCategory} for session ${this.goodSessionId}: Session is not waiting for incident category (current state: ${CHATBOT_STATE.COMPLETED})`,
             )
           })
@@ -166,6 +172,12 @@ describe('braveAlerter.js unit tests: handleIncidentCategory', () => {
           )
         })
 
+        it('should return the error message as JSON', () => {
+          expect(this.fakeExpressResponse.json).to.be.calledWith(
+            `Failed to record incident category ${this.incidentCategory} for session ${this.goodSessionId}: Invalid category for client`,
+          )
+        })
+
         it('should not call alertSessionChangedCallback', () => {
           expect(this.braveAlerter.alertSessionChangedCallback).not.to.be.called
         })
@@ -205,6 +217,12 @@ describe('braveAlerter.js unit tests: handleIncidentCategory', () => {
 
       it('should log the failure', () => {
         expect(helpers.logError).to.be.calledWith(
+          `Failed to record incident category ${this.incidentCategory} for session ${this.badSessionId}: No corresponding session`,
+        )
+      })
+
+      it('should return the error message as JSON', () => {
+        expect(this.fakeExpressResponse.json).to.be.calledWith(
           `Failed to record incident category ${this.incidentCategory} for session ${this.badSessionId}: No corresponding session`,
         )
       })

--- a/test/unit/testBraveAlerter/testBraveAlerterHandleRespondToAlertSession.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterHandleRespondToAlertSession.js
@@ -77,7 +77,7 @@ describe('braveAlerter.js unit tests: handleRespondToAlertSession', () => {
         })
 
         it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -133,7 +133,7 @@ describe('braveAlerter.js unit tests: handleRespondToAlertSession', () => {
         })
 
         it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -185,7 +185,7 @@ describe('braveAlerter.js unit tests: handleRespondToAlertSession', () => {
         })
 
         it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -241,7 +241,7 @@ describe('braveAlerter.js unit tests: handleRespondToAlertSession', () => {
         })
 
         it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -297,7 +297,7 @@ describe('braveAlerter.js unit tests: handleRespondToAlertSession', () => {
         })
 
         it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {
@@ -353,7 +353,7 @@ describe('braveAlerter.js unit tests: handleRespondToAlertSession', () => {
         })
 
         it('should return the active alerts', () => {
-          expect(this.fakeExpressResponse.json).to.be.calledWith(JSON.stringify(this.activeAlerts))
+          expect(this.fakeExpressResponse.json).to.be.calledWith(this.activeAlerts)
         })
 
         it('should return 200', () => {


### PR DESCRIPTION
I fixed this for all the other API calls used by the app, but forgot this one because it was in this different file. Basically, the app immediately tries to parse the response as though it were JSON, so by only sending the error message back, instead of seeing the error message, I'd instead get "JSON parse error"  (which is less helpful 😉 )

## Test Plan
- :heavy_check_mark: Deploy to chatbot-dev and dev.sensors
- :heavy_check_mark: On my emulator, hit the `POST /alert/designatedevice` endpoint with valid values
   - :heavy_check_mark: Logs the API key, repsonder push ID, and verification code on both servers
   - :heavy_check_mark: No error message on app
- :heavy_check_mark: On my emulator, hit the `POST /alert/designatedevice` endpoint with valid invalid values (e.g. not provide the API key)
   - :heavy_check_mark: Logs error on both servers
   - :heavy_check_mark: Error message on app is NOT the "could not parse JSON error" but instead is something that is useful (e.g. says that the API key was missing)
- :heavy_check_mark:  On my emulator hit all the changed endpoints when there is data, when there is no data, and when it returns an error