### PR TITLE
Use express.json instead of body-parser (CU-13kqxyt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Use `express.json()` instead of `body-parser` (CU-13kqxyt).
+
 ## [6.1.0] - 2021-11-04
 
 ### Added

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -1,6 +1,5 @@
 // Third-party dependencies
 const express = require('express')
-const jsonBodyParser = require('body-parser').json()
 const Validator = require('express-validator')
 
 // In-house dependencies
@@ -11,6 +10,8 @@ const helpers = require('./helpers')
 const twilio = require('./twilio')
 const OneSignal = require('./oneSignal')
 const { handleDesignateDevice } = require('./designateDevice')
+
+const jsonBodyParser = express.json()
 
 class BraveAlerter {
   // See README for description of parameters

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
     "axios": "^0.21.2",
-    "body-parser": "^1.19.0",
     "chalk": "^4.1.0",
     "dotenv": "^7.0.0",
     "express": "^4.17.1",


### PR DESCRIPTION
- body-parser is now included within Express. By using it this way,
  we are sure to get the updates that Express wants us to use. This
  will hopefully reduce our risk of having old code in our code base