### PR TITLE
Add datetime helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- generateCalculatedTimeDifferenceString function.
+
+### Security
+
+- Updated dependencies.
+
 ## [6.5.0] - 2022-01-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- generateCalculatedTimeDifferenceString function.
+- generateCalculatedTimeDifferenceString helper function.
+- formatDateTimeForDashboard helper.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -380,6 +380,14 @@ An enum of the types of Brave Devices that use `brave-alert-lib`.
 
 A collection of functions that are useful across the Brave NodeJS applications.
 
+### formatDateTimeForDashboard(date)
+
+Format the given `date` into English and Pacific Time
+
+** date (Date):** the JS Date object to format
+
+** Returns:** a string with the given `date` formatted into English and Pacific Time
+
 ### formatExpressValidationErrors(expressErrorObject)
 
 A function that can be sent as an argument to the Express Validation `formatWith` function (https://express-validator.github.io/docs/validation-result-api.html#formatwithformatter). It takes an Express error object and returns a consistent, readable string to be used for error logs and sending in error HTTP messages.

--- a/README.md
+++ b/README.md
@@ -400,6 +400,16 @@ In the test environment, returns the test version of the environment variable wi
 
 **Returns:** the correct environment variable for the situation.
 
+### generateCalculatedTimeDifferenceString(timeToCompare, db)
+
+Returns an English string containing the time difference between the given `timeToCompare` and now according to an async function `db.getCurrentTime()`.
+
+**timeToCompare (Date):** the date to compare to
+
+**db (object):** object containing an async function `getCurrentTime()` that resolves to a Date respresenting the current time
+
+**Returns:** the English string containing the time difference between the given `timeToCompare` and the date returned by `db.getCurrentTime`
+
 ### isTestEnvironment()
 
 Determines whether we are executing in a test environment (i.e. with the value of NODE_ENV === 'test').

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,6 +9,7 @@ const Sentry = require('@sentry/node')
 const Tracing = require('@sentry/tracing')
 const chalk = require('chalk')
 const dotenv = require('dotenv')
+const { DateTime } = require('luxon')
 
 // In-house dependencies
 const ALERT_TYPE = require('./alertTypeEnum')
@@ -166,7 +167,15 @@ async function generateCalculatedTimeDifferenceString(timeToCompare, db) {
   return returnString
 }
 
+const DASHBOARD_TIMEZONE = 'America/Vancouver'
+const DASHBOARD_FORMAT = 'y MMM d, TTT'
+
+function formatDateTimeForDashboard(date) {
+  return DateTime.fromJSDate(date, { zone: 'utc' }).setZone(DASHBOARD_TIMEZONE).toFormat(DASHBOARD_FORMAT)
+}
+
 module.exports = {
+  formatDateTimeForDashboard,
   formatExpressValidationErrors,
   generateCalculatedTimeDifferenceString,
   getAlertTypeDisplayName,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -125,8 +125,50 @@ function getAlertTypeDisplayName(alertType) {
   return displayName
 }
 
+async function generateCalculatedTimeDifferenceString(timeToCompare, db) {
+  const daySecs = 24 * 60 * 60
+  const hourSecs = 60 * 60
+  const minSecs = 60
+  let returnString = ''
+  let numDays = 0
+  let numHours = 0
+  let numMins = 0
+  const currentTime = await db.getCurrentTime()
+
+  let diffSecs = (currentTime - timeToCompare) / 1000
+
+  if (diffSecs >= daySecs) {
+    numDays = Math.floor(diffSecs / daySecs)
+    diffSecs %= daySecs
+  }
+  returnString += `${numDays} ${numDays === 1 ? 'day, ' : 'days, '}`
+
+  if (diffSecs >= hourSecs) {
+    numHours = Math.floor(diffSecs / hourSecs)
+    diffSecs %= hourSecs
+  }
+  returnString += `${numHours} ${numHours === 1 ? 'hour, ' : 'hours, '}`
+
+  if (diffSecs >= minSecs) {
+    numMins = Math.floor(diffSecs / minSecs)
+  }
+  returnString += `${numMins} ${numMins === 1 ? 'minute' : 'minutes'}`
+
+  if (numDays + numHours === 0) {
+    diffSecs %= minSecs
+    const numSecs = Math.floor(diffSecs)
+
+    returnString += `, ${numSecs} ${numSecs === 1 ? 'second' : 'seconds'}`
+  }
+
+  returnString += ' ago'
+
+  return returnString
+}
+
 module.exports = {
   formatExpressValidationErrors,
+  generateCalculatedTimeDifferenceString,
   getAlertTypeDisplayName,
   getEnvVar,
   isTestEnvironment,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2508,6 +2508,11 @@
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
       "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
+    "luxon": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",
+      "integrity": "sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg=="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^7.0.0",
     "express": "^4.17.1",
     "express-validator": "^6.10.0",
+    "luxon": "^2.3.0",
     "twilio": "^3.54.2"
   },
   "devDependencies": {

--- a/test/unit/testHelpers/testFormatDateTimeForDashboard.js
+++ b/test/unit/testHelpers/testFormatDateTimeForDashboard.js
@@ -1,0 +1,13 @@
+// Third-party dependencies
+const { expect } = require('chai')
+const { describe, it } = require('mocha')
+
+// In-house dependencies
+const { formatDateTimeForDashboard } = require('../../../lib/helpers')
+
+describe('dashboard.js unit tests: formatDateTimeForDashboard', () => {
+  it('should format the JS date into a English Pacific Timezone string', () => {
+    const actual = formatDateTimeForDashboard(new Date('2022-01-08T00:29:00.000Z'))
+    expect(actual).to.equal('2022 Jan 7, 16:29:00 PST')
+  })
+})


### PR DESCRIPTION
- `generateCalculatedTimeDifferenceString` is from Sensors but I want to also use it in Buttons
- `formatDateTimeForDashboard` is from Buttons but I want to also use it in Sensors.

## Test plan
- :heavy_check_mark: Deploy to chatbot-dev
- :heavy_check_mark: Look at the new Vitals Page and see that the `generateCalculatedTimeDifferenceString` values are formatted correctly based on the timestamps in the DB
- :heavy_check_mark: Look at the new Vitals Page and see that the tooltip `formatDateTimeForDashboard` values are formatted correctly based on the timestamps in the DB