### PR TITLE
Add DB debug logging that is controlled by an env variable (CU-2atyr1z)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,7 @@ CLICKUP_TEAM_NAME_TEST=Our Team Name
 # ID of the Brave ClickUp Team
 # Get this from Clickup --> In the URL https://app.clickup.com/<this number here>/home
 CLICKUP_TEAM_ID_TEST=123
+
+# Flag to turn on (true) or off (false) database debugging logs
+# Unless specifically investigating something, this should be off (false)
+IS_DB_LOGGING=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- DB debug logging that is controlled by an environment variable (CU-2atyr1z).
+
 ## [6.7.0] - 2022-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ On your local machine, in the `brave-alert-lib` repository:
    - `CLICKUP_TEAM_NAME_TEST`: The full name of the Brave ClickUp Team
    - `CLICKUP_TEAM_ID`: The ID of the Brave ClickUp Team
    - `CLICKUP_TEAM_ID_TEST`: The ID of the Brave ClickUp Team
+   - `IS_DB_LOGGING`: Whether (true) or not (false) we are printing DB debug logs to the console
 
 # How to setup a local dev environment
 
@@ -453,6 +454,12 @@ Returns an English string containing the time difference between the given `time
 **db (object):** object containing an async function `getCurrentTime()` that resolves to a Date respresenting the current time
 
 **Returns:** the English string containing the time difference between the given `timeToCompare` and the date returned by `db.getCurrentTime`
+
+### isDbLogging()
+
+Controls whether the program should output DB debug logs.
+
+**Returns:** `true` if the program should output DB debug logs. `false` otherwise. Under normal circumstances, this should be `false`.
 
 ### isTestEnvironment()
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -21,6 +21,10 @@ function isTestEnvironment() {
   return process.env.NODE_ENV === 'test'
 }
 
+function isDbLogging() {
+  return process.env.IS_DB_LOGGING === 'true'
+}
+
 // Code mostly from https://express-validator.github.io/docs/validation-result-api.html#formatwithformatter
 function formatExpressValidationErrors({ msg, param, nestedErrors }) {
   if (nestedErrors) {
@@ -87,12 +91,19 @@ function sleep(millis) {
 }
 
 async function runQuery(functionName, queryString, queryParams, pool, clientParam) {
+  if (isDbLogging()) {
+    log(`STARTED: ${functionName}`)
+  }
+
   let client = clientParam
   const transactionMode = client !== undefined
 
   try {
     if (!transactionMode) {
       client = await pool.connect()
+      if (isDbLogging()) {
+        log(`CONNECTED: ${functionName}`)
+      }
     }
 
     return await client.query(queryString, queryParams)
@@ -105,6 +116,10 @@ async function runQuery(functionName, queryString, queryParams, pool, clientPara
       } catch (err) {
         logError(`${functionName}: Error releasing client: ${err}`)
       }
+    }
+
+    if (isDbLogging()) {
+      log(`COMPLETED: ${functionName}`)
     }
   }
 }
@@ -180,6 +195,7 @@ module.exports = {
   generateCalculatedTimeDifferenceString,
   getAlertTypeDisplayName,
   getEnvVar,
+  isDbLogging,
   isTestEnvironment,
   isValidRequest,
   log,


### PR DESCRIPTION
- So that I can better debug transaction/deadlock issues in
  production. This will output to the console the start and end of
  each SQL query that uses the `runQuery` command (which should be
  all of them except for BEGIN, COMMIT, and ROLLBACK)

## Test plan
- :heavy_check_mark: Deploy to Sensors Dev
- :heavy_check_mark: Run smoke tests on Sensors Dev
   - :heavy_check_mark: With IS_DB_LOGGING=true
   - :heavy_check_mark: With IS_DB_LOGGING=false
   - :heavy_check_mark: With IS_DB_LOGGING absent from the .env (should behave as though IS_DB_LOGGING=false)