### PR TITLE
Allow client-specific internationalization (CU-2dtutrx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Client-specific language settings (CU-2dtutrx).
+
 ## [7.0.0] - 2022-06-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ The main class of this library. It is used to send single alerts or to start ale
 
 **getHistoricAlertsByAlertApiKey (async function(alertApiKey, maxHistoricAlerts)):** function that returns an array of at most `maxHistoricAlerts` `HistoricAlert` objects whose Alert API Key matches the given `alertApiKey`, or the empty array if there is no match.
 
-**getReturnMessageToRespondedByPhoneNumber (function(fromAlertState, toAlertState, validIncidentCategories)):** function that returns the message to send to the RespondedByPhoneNumber when there is a transition from `fromAlertState` to `toAlertState` (note that `fromAlertState` and `toAlertState` will have the same value for cases where a transition doesn't change the alert state). Sometimes this message needs to know the `validIncidentCategories` for the particular session.
+**getReturnMessageToRespondedByPhoneNumber (function(language, fromAlertState, toAlertState, validIncidentCategories)):** function that returns the message to send to the RespondedByPhoneNumber when there is a transition from `fromAlertState` to `toAlertState` (note that `fromAlertState` and `toAlertState` will have the same value for cases where a transition doesn't change the alert state). Sometimes this message needs to know the `validIncidentCategories` for the particular session.
 
-**getReturnMessageToOtherResponderPhoneNumbers (function(fromAlertState, toAlertState, selectedIncidentCategory)):** function that returns the message to send to all the other Responder Phone Numbers (i.e. not the RespondedByPhoneNumber) when there is a transition from `fromAlertState` to `toAlertState` (note that `fromAlertState` and `toAlertState` will have the same value for cases where a transition doesn't change the alert state). Sometimes this message needs to know which incidentCategory was chosen by the respondedByPhoneNumber for the particular session.
+**getReturnMessageToOtherResponderPhoneNumbers (function(language, fromAlertState, toAlertState, selectedIncidentCategory)):** function that returns the message to send to all the other Responder Phone Numbers (i.e. not the RespondedByPhoneNumber) when there is a transition from `fromAlertState` to `toAlertState` (note that `fromAlertState` and `toAlertState` will have the same value for cases where a transition doesn't change the alert state). Sometimes this message needs to know which incidentCategory was chosen by the respondedByPhoneNumber for the particular session.
 
 ### getRouter()
 
@@ -300,6 +300,8 @@ Note that these line up one-to-one with the `validIncidentCategoryKeys`. So for 
 
 Note that these line up one-to-one with the `validIncidentCategoryKeys`. So for any `i`, `validIncidentCategories[i]` is the
 human-readable DB value for the `validIncidentCategoryKeys[i]` value given by the Responder in a text message.
+
+**language (string):** The language code in which client-facing messages should be sent.
 
 ## `ActiveAlert` class
 

--- a/lib/alertSession.js
+++ b/lib/alertSession.js
@@ -7,6 +7,7 @@ class AlertSession {
     responderPhoneNumbers,
     validIncidentCategoryKeys,
     validIncidentCategories,
+    language,
   ) {
     this.sessionId = sessionId
     this.alertState = alertState
@@ -15,6 +16,7 @@ class AlertSession {
     this.responderPhoneNumbers = responderPhoneNumbers
     this.validIncidentCategoryKeys = validIncidentCategoryKeys
     this.validIncidentCategories = validIncidentCategories
+    this.language = language
   }
 }
 

--- a/lib/alertStateMachine.js
+++ b/lib/alertStateMachine.js
@@ -6,7 +6,7 @@ class AlertStateMachine {
     this.getReturnMessageToOtherResponderPhoneNumbers = getReturnMessageToOtherResponderPhonesNumbers
   }
 
-  processStateTransitionWithMessage(currentAlertState, messageText, validIncidentCategoryKeys, validIncidentCategories) {
+  processStateTransitionWithMessage(currentAlertState, messageText, validIncidentCategoryKeys, validIncidentCategories, language) {
     let nextAlertState
     let incidentCategoryKey
     let selectedIncidentCategory
@@ -39,11 +39,13 @@ class AlertStateMachine {
       nextAlertState,
       incidentCategoryKey,
       returnMessageToRespondedByPhoneNumber: this.getReturnMessageToRespondedByPhoneNumber(
+        language,
         currentAlertState,
         nextAlertState,
         validIncidentCategories,
       ),
       returnMessageToOtherResponderPhoneNumbers: this.getReturnMessageToOtherResponderPhoneNumbers(
+        language,
         currentAlertState,
         nextAlertState,
         selectedIncidentCategory,

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -286,6 +286,7 @@ class BraveAlerter {
         message,
         alertSession.validIncidentCategoryKeys,
         alertSession.validIncidentCategories,
+        alertSession.language,
       )
 
       // Store the results and idemopotently get the respondedByPhoneNumber for the session

--- a/lib/models/Client.js
+++ b/lib/models/Client.js
@@ -12,6 +12,7 @@ class Client {
     heartbeatPhoneNumbers,
     incidentCategories,
     isActive,
+    language,
     createdAt,
     updatedAt,
   ) {
@@ -27,6 +28,7 @@ class Client {
     this.heartbeatPhoneNumbers = heartbeatPhoneNumbers
     this.incidentCategories = incidentCategories
     this.isActive = isActive
+    this.language = language
     this.createdAt = createdAt
     this.updatedAt = updatedAt
   }

--- a/lib/models/factories.js
+++ b/lib/models/factories.js
@@ -13,6 +13,7 @@ async function clientDBFactory(db, overrides = {}) {
     overrides.heartbeatPhoneNumbers !== undefined ? overrides.heartbeatPhoneNumbers : ['+18889997777'],
     overrides.incidentCategories !== undefined ? overrides.incidentCategories : ['Accidental', 'Safer Use', 'Unsafe Guest', 'Overdose', 'Other'],
     overrides.isActive !== undefined ? overrides.isActive : true,
+    overrides.language !== undefined ? overrides.language : 'en',
   )
 
   return client
@@ -32,6 +33,7 @@ function clientFactory(overrides = {}) {
     overrides.heartbeatPhoneNumbers !== undefined ? overrides.heartbeatPhoneNumbers : ['+18889997777'],
     overrides.incidentCategories !== undefined ? overrides.incidentCategories : ['Accidental', 'Safer Use', 'Unsafe Guest', 'Overdose', 'Other'],
     overrides.isActive !== undefined ? overrides.isActive : true,
+    overrides.language !== undefined ? overrides.language : 'en',
     overrides.createdAt !== undefined ? overrides.createdAt : new Date('2021-11-04T22:28:28.0248Z'),
     overrides.updatedAt !== undefined ? overrides.updatedAt : new Date('2021-11-05T02:02:22.234Z'),
   )

--- a/test/integration/testHappyPathTwilio.js
+++ b/test/integration/testHappyPathTwilio.js
@@ -24,6 +24,7 @@ const initialMessage = 'There was an alert in Bathroom 4'
 const incidentCategoryKey = '1'
 const validIncidentCategoryKeys = ['1', '2']
 const validIncidentCategories = ['Cat 1', 'Cat 2']
+const language = 'my_lng'
 const initialAlertInfo = {
   sessionId,
   toPhoneNumbers: [responderPhoneNumber, otherResponderPhoneNumber],
@@ -47,6 +48,7 @@ describe('happy path Twilio integration test: responder responds right away and 
       responderPhoneNumbers: [responderPhoneNumber, otherResponderPhoneNumber],
       validIncidentCategoryKeys,
       validIncidentCategories,
+      language,
     })
 
     this.braveAlerter = testingHelpers.braveAlerterFactory({
@@ -94,12 +96,12 @@ describe('happy path Twilio integration test: responder responds right away and 
     expect(twilioHelpers.sendTwilioMessage).to.be.calledWithExactly(
       responderPhoneNumber,
       devicePhoneNumber,
-      'To RespondedByPhoneNumber: STARTED --> WAITING_FOR_CATEGORY',
+      'To RespondedByPhoneNumber (my_lng): STARTED --> WAITING_FOR_CATEGORY',
     )
     expect(twilioHelpers.sendTwilioMessage).to.be.calledWithExactly(
       otherResponderPhoneNumber,
       devicePhoneNumber,
-      'To OtherResponderPhoneNumbers: STARTED --> WAITING_FOR_CATEGORY',
+      'To OtherResponderPhoneNumbers (my_lng): STARTED --> WAITING_FOR_CATEGORY',
     )
 
     // Expect the state to change to WAITING_FOR_CATEGORY
@@ -120,12 +122,12 @@ describe('happy path Twilio integration test: responder responds right away and 
     expect(twilioHelpers.sendTwilioMessage).to.be.calledWithExactly(
       responderPhoneNumber,
       devicePhoneNumber,
-      'To RespondedByPhoneNumber: WAITING_FOR_CATEGORY --> COMPLETED',
+      'To RespondedByPhoneNumber (my_lng): WAITING_FOR_CATEGORY --> COMPLETED',
     )
     expect(twilioHelpers.sendTwilioMessage).to.be.calledWithExactly(
       otherResponderPhoneNumber,
       devicePhoneNumber,
-      'To OtherResponderPhoneNumbers: WAITING_FOR_CATEGORY --> COMPLETED',
+      'To OtherResponderPhoneNumbers (my_lng): WAITING_FOR_CATEGORY --> COMPLETED',
     )
 
     // Expect the state to change to COMPLETED and that the incident cateogry is updated to what the responder sent

--- a/test/testingHelpers.js
+++ b/test/testingHelpers.js
@@ -35,12 +35,12 @@ function dummyGetNewNotificationsCountByAlertApiKey() {
   return 'getNewNotificationsCountByAlertApiKey'
 }
 
-function dummyGetReturnMessageToRespondedByPhoneNumber(fromAlertState, toAlertState) {
-  return `To RespondedByPhoneNumber: ${fromAlertState} --> ${toAlertState}`
+function dummyGetReturnMessageToRespondedByPhoneNumber(language, fromAlertState, toAlertState) {
+  return `To RespondedByPhoneNumber (${language}): ${fromAlertState} --> ${toAlertState}`
 }
 
-function dummyGetReturnMessageToOtherResponderPhoneNumbers(fromAlertState, toAlertState) {
-  return `To OtherResponderPhoneNumbers: ${fromAlertState} --> ${toAlertState}`
+function dummyGetReturnMessageToOtherResponderPhoneNumbers(language, fromAlertState, toAlertState) {
+  return `To OtherResponderPhoneNumbers (${language}): ${fromAlertState} --> ${toAlertState}`
 }
 
 function braveAlerterFactory(overrides = {}) {
@@ -69,6 +69,7 @@ function alertSessionFactory(overrides = {}) {
     overrides.responderPhoneNumbers !== undefined ? overrides.responderPhoneNumbers : undefined,
     overrides.validIncidentCategoryKeys !== undefined ? overrides.validIncidentCategoryKeys : undefined,
     overrides.validIncidentCategories !== undefined ? overrides.validIncidentCategories : undefined,
+    overrides.language !== undefined ? overrides.language : undefined,
   )
 }
 

--- a/test/unit/testAlertStateMachine.js
+++ b/test/unit/testAlertStateMachine.js
@@ -4,16 +4,17 @@ const { beforeEach, describe, it } = require('mocha')
 const CHATBOT_STATE = require('../../lib/chatbotStateEnum')
 const AlertStateMachine = require('../../lib/alertStateMachine')
 
-function dummyGetReturnMessageToRespondedByPhoneNumber(fromAlertState, toAlertState, incidentCategories) {
-  return `To RespondedByPhoneNumber: ${fromAlertState} --> ${toAlertState} with ${JSON.stringify(incidentCategories)}`
+function dummyGetReturnMessageToRespondedByPhoneNumber(language, fromAlertState, toAlertState, incidentCategories) {
+  return `To RespondedByPhoneNumber (${language}): ${fromAlertState} --> ${toAlertState} with ${JSON.stringify(incidentCategories)}`
 }
 
-function dummyGetReturnMessageToOtherResponderPhoneNumbers(fromAlertState, toAlertState, selectedIncidentCategory) {
-  return `To OtherResponderPhoneNumbers: ${fromAlertState} --> ${toAlertState} with "${selectedIncidentCategory}"`
+function dummyGetReturnMessageToOtherResponderPhoneNumbers(language, fromAlertState, toAlertState, selectedIncidentCategory) {
+  return `To OtherResponderPhoneNumbers (${language}): ${fromAlertState} --> ${toAlertState} with "${selectedIncidentCategory}"`
 }
 
 const dummyIncidentCategoryKeys = ['1', '2', '3', '4']
 const dummyIncidentCategories = ['One', 'Two', 'Three', 'Four']
+const dummyLanguage = 'my_lng'
 
 describe('alertStateMachine.js unit tests:', () => {
   describe('constructor', () => {
@@ -45,6 +46,7 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(nextAlertState).to.equal(CHATBOT_STATE.WAITING_FOR_CATEGORY)
@@ -56,6 +58,7 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(incidentCategoryKey).to.be.undefined
@@ -67,10 +70,11 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(returnMessageToRespondedByPhoneNumber).to.equal(
-          `To RespondedByPhoneNumber: ${CHATBOT_STATE.STARTED} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`,
+          `To RespondedByPhoneNumber (${dummyLanguage}): ${CHATBOT_STATE.STARTED} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`,
         )
       })
 
@@ -80,10 +84,11 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(returnMessageToOtherResponderPhoneNumbers).to.equal(
-          `To OtherResponderPhoneNumbers: ${CHATBOT_STATE.STARTED} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with "undefined"`,
+          `To OtherResponderPhoneNumbers (${dummyLanguage}): ${CHATBOT_STATE.STARTED} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with "undefined"`,
         )
       })
     })
@@ -95,6 +100,7 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(nextAlertState).to.equal(CHATBOT_STATE.WAITING_FOR_CATEGORY)
@@ -106,6 +112,7 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(incidentCategoryKey).to.be.undefined
@@ -117,10 +124,11 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(returnMessageToRespondedByPhoneNumber).to.equal(
-          `To RespondedByPhoneNumber: ${CHATBOT_STATE.WAITING_FOR_REPLY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`,
+          `To RespondedByPhoneNumber (${dummyLanguage}): ${CHATBOT_STATE.WAITING_FOR_REPLY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`,
         )
       })
 
@@ -130,10 +138,11 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(returnMessageToOtherResponderPhoneNumbers).to.equal(
-          `To OtherResponderPhoneNumbers: ${CHATBOT_STATE.WAITING_FOR_REPLY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with "undefined"`,
+          `To OtherResponderPhoneNumbers (${dummyLanguage}): ${CHATBOT_STATE.WAITING_FOR_REPLY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with "undefined"`,
         )
       })
     })
@@ -146,6 +155,7 @@ describe('alertStateMachine.js unit tests:', () => {
             '3',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(nextAlertState).to.equal(CHATBOT_STATE.COMPLETED)
@@ -157,6 +167,7 @@ describe('alertStateMachine.js unit tests:', () => {
             '1',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(incidentCategoryKey).to.equal('1')
@@ -168,6 +179,7 @@ describe('alertStateMachine.js unit tests:', () => {
             '4',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(incidentCategoryKey).to.equal('4')
@@ -179,6 +191,7 @@ describe('alertStateMachine.js unit tests:', () => {
             '   2    ',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(incidentCategoryKey).to.equal('2')
@@ -190,10 +203,11 @@ describe('alertStateMachine.js unit tests:', () => {
             '3',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(returnMessageToRespondedByPhoneNumber).to.equal(
-            `To RespondedByPhoneNumber: ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.COMPLETED} with ["One","Two","Three","Four"]`,
+            `To RespondedByPhoneNumber (${dummyLanguage}): ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.COMPLETED} with ["One","Two","Three","Four"]`,
           )
         })
 
@@ -203,10 +217,11 @@ describe('alertStateMachine.js unit tests:', () => {
             '3',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(returnMessageToOtherResponderPhoneNumbers).to.equal(
-            `To OtherResponderPhoneNumbers: ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.COMPLETED} with "Three"`,
+            `To OtherResponderPhoneNumbers (${dummyLanguage}): ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.COMPLETED} with "Three"`,
           )
         })
       })
@@ -218,6 +233,7 @@ describe('alertStateMachine.js unit tests:', () => {
             '0',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(nextAlertState).to.equal(CHATBOT_STATE.WAITING_FOR_CATEGORY)
@@ -229,6 +245,7 @@ describe('alertStateMachine.js unit tests:', () => {
             '0',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(incidentCategoryKey).to.be.undefined
@@ -240,10 +257,11 @@ describe('alertStateMachine.js unit tests:', () => {
             '0',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(returnMessageToRespondedByPhoneNumber).to.equal(
-            `To RespondedByPhoneNumber: ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`,
+            `To RespondedByPhoneNumber (${dummyLanguage}): ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`,
           )
         })
 
@@ -253,10 +271,11 @@ describe('alertStateMachine.js unit tests:', () => {
             '0',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(returnMessageToOtherResponderPhoneNumbers).to.equal(
-            `To OtherResponderPhoneNumbers: ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with "undefined"`,
+            `To OtherResponderPhoneNumbers (${dummyLanguage}): ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with "undefined"`,
           )
         })
       })
@@ -268,6 +287,7 @@ describe('alertStateMachine.js unit tests:', () => {
             '5',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(nextAlertState).to.equal(CHATBOT_STATE.WAITING_FOR_CATEGORY)
@@ -279,6 +299,7 @@ describe('alertStateMachine.js unit tests:', () => {
             '5',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(incidentCategoryKey).to.be.undefined
@@ -290,10 +311,11 @@ describe('alertStateMachine.js unit tests:', () => {
             '5',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(returnMessageToRespondedByPhoneNumber).to.equal(
-            `To RespondedByPhoneNumber: ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`,
+            `To RespondedByPhoneNumber (${dummyLanguage}): ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`,
           )
         })
 
@@ -303,10 +325,11 @@ describe('alertStateMachine.js unit tests:', () => {
             '5',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(returnMessageToOtherResponderPhoneNumbers).to.equal(
-            `To OtherResponderPhoneNumbers: ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with "undefined"`,
+            `To OtherResponderPhoneNumbers (${dummyLanguage}): ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with "undefined"`,
           )
         })
       })
@@ -318,6 +341,7 @@ describe('alertStateMachine.js unit tests:', () => {
             '2A3',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(nextAlertState).to.equal(CHATBOT_STATE.WAITING_FOR_CATEGORY)
@@ -329,6 +353,7 @@ describe('alertStateMachine.js unit tests:', () => {
             '  2A3  ',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(incidentCategoryKey).to.be.undefined
@@ -340,10 +365,11 @@ describe('alertStateMachine.js unit tests:', () => {
             '2A3',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(returnMessageToRespondedByPhoneNumber).to.equal(
-            `To RespondedByPhoneNumber: ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`,
+            `To RespondedByPhoneNumber (${dummyLanguage}): ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with ["One","Two","Three","Four"]`,
           )
         })
 
@@ -353,10 +379,11 @@ describe('alertStateMachine.js unit tests:', () => {
             '2A3',
             dummyIncidentCategoryKeys,
             dummyIncidentCategories,
+            dummyLanguage,
           )
 
           expect(returnMessageToOtherResponderPhoneNumbers).to.equal(
-            `To OtherResponderPhoneNumbers: ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with "undefined"`,
+            `To OtherResponderPhoneNumbers (${dummyLanguage}): ${CHATBOT_STATE.WAITING_FOR_CATEGORY} --> ${CHATBOT_STATE.WAITING_FOR_CATEGORY} with "undefined"`,
           )
         })
       })
@@ -369,6 +396,7 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(nextAlertState).to.equal(CHATBOT_STATE.COMPLETED)
@@ -380,6 +408,7 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(incidentCategoryKey).to.be.undefined
@@ -391,10 +420,11 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(returnMessageToRespondedByPhoneNumber).to.equal(
-          `To RespondedByPhoneNumber: ${CHATBOT_STATE.COMPLETED} --> ${CHATBOT_STATE.COMPLETED} with ["One","Two","Three","Four"]`,
+          `To RespondedByPhoneNumber (${dummyLanguage}): ${CHATBOT_STATE.COMPLETED} --> ${CHATBOT_STATE.COMPLETED} with ["One","Two","Three","Four"]`,
         )
       })
 
@@ -404,10 +434,11 @@ describe('alertStateMachine.js unit tests:', () => {
           '3',
           dummyIncidentCategoryKeys,
           dummyIncidentCategories,
+          dummyLanguage,
         )
 
         expect(returnMessageToOtherResponderPhoneNumbers).to.equal(
-          `To OtherResponderPhoneNumbers: ${CHATBOT_STATE.COMPLETED} --> ${CHATBOT_STATE.COMPLETED} with "undefined"`,
+          `To OtherResponderPhoneNumbers (${dummyLanguage}): ${CHATBOT_STATE.COMPLETED} --> ${CHATBOT_STATE.COMPLETED} with "undefined"`,
         )
       })
     })


### PR DESCRIPTION
- Add `language` as a property of the `Client` object
- Take `language` as a parameter where needed so that it can be passed back to Buttons/Sensor code for translation

## Tests
- :heavy_check_mark: Passes the Buttons tests in https://github.com/bravetechnologycoop/BraveButtons/pull/167