### PR TITLE
Change `getAlertSessionByPhoneNumber` name and parameter list (CU-2fk3y8a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Name and parameter list for `getAlertSessionByPhoneNumber` to permit the changes needed to allow Twilio numbers to be shared across clients (CU-2fk3y8a).
+
 ## [8.1.0] - 2022-07-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ Reference: https://docs.travis-ci.com/user/environment-variables/#encrypting-env
 
 The main class of this library. It is used to send single alerts or to start alert sessions with the responders.
 
-### constructor(getAlertSession, getAlertSessionByPhoneNumber, alertSessionChangedCallback, getLocationByAlertApiKey, getActiveAlertsByAlertApiKey, getHistoricAlertsByAlertApiKey, getReturnMessageToRespondedByPhoneNumber, getReturnMessageToOtherResponderPhoneNumbers)
+### constructor(getAlertSession, getAlertSessionByPhoneNumbers, alertSessionChangedCallback, getLocationByAlertApiKey, getActiveAlertsByAlertApiKey, getHistoricAlertsByAlertApiKey, getReturnMessageToRespondedByPhoneNumber, getReturnMessageToOtherResponderPhoneNumbers)
 
 **getAlertSession (async function(sessionId)):** function that returns the AlertSession object with the given `sessionId`
 
-**getAlertSessionByPhoneNumber (async function(toPhoneNumber)):** function that returns the AlertSession object for the most recent unfinished session with the given phone number
+**getAlertSessionByPhoneNumbers (async function(devicePhoneNumber, responderPhoneNumber)):** function that returns the AlertSession object for the most recent unfinished session for the device with the given devicePhoneNumber and client with the given responderPhoneNumber
 
 **getAlertSessionBySessionIdAndAlertApiKey (async function(sessionId, alertApiKey)):** function that returns the AlertSession object with the given `sessionId` if and only if it is a session for a client using the given `alertApiKey`
 

--- a/lib/braveAlerter.js
+++ b/lib/braveAlerter.js
@@ -18,7 +18,7 @@ class BraveAlerter {
   // eslint-disable-next-line prettier/prettier
   constructor(
     getAlertSession,
-    getAlertSessionByPhoneNumber,
+    getAlertSessionByPhoneNumbers,
     getAlertSessionBySessionIdAndAlertApiKey,
     alertSessionChangedCallback,
     getLocationByAlertApiKey,
@@ -29,7 +29,7 @@ class BraveAlerter {
     getReturnMessageToOtherResponderPhoneNumbers,
   ) {
     this.getAlertSession = getAlertSession
-    this.getAlertSessionByPhoneNumber = getAlertSessionByPhoneNumber
+    this.getAlertSessionByPhoneNumbers = getAlertSessionByPhoneNumbers
     this.getAlertSessionBySessionIdAndAlertApiKey = getAlertSessionBySessionIdAndAlertApiKey
     this.alertSessionChangedCallback = alertSessionChangedCallback
     this.getLocationByAlertApiKey = getLocationByAlertApiKey
@@ -260,18 +260,10 @@ class BraveAlerter {
       const toPhoneNumber = request.body.To
       const message = request.body.Body
 
-      const alertSession = await this.getAlertSessionByPhoneNumber(toPhoneNumber)
+      const alertSession = await this.getAlertSessionByPhoneNumbers(toPhoneNumber, fromPhoneNumber)
       if (alertSession === null) {
         helpers.log(`Received twilio message from ${fromPhoneNumber} to ${toPhoneNumber} with no corresponding open session`)
         response.status(200).send()
-        return
-      }
-
-      // Ensure message was sent from the Responder phone
-      if (!alertSession.responderPhoneNumbers.includes(fromPhoneNumber)) {
-        const errorMessage = `Bad request to ${request.path}: ${fromPhoneNumber} is not the responder phone for ${alertSession.sessionId}`
-        helpers.logError(errorMessage)
-        response.status(400).send(errorMessage)
         return
       }
 

--- a/test/integration/testFallbackFlowTwilio.js
+++ b/test/integration/testFallbackFlowTwilio.js
@@ -51,7 +51,7 @@ describe('fallback flow with Twilio: responder never responds so fallback messag
 
     this.braveAlerter = testingHelpers.braveAlerterFactory({
       getAlertSession: sandbox.stub().returns(this.currentAlertSession),
-      getAlertSessionByPhoneNumber: sandbox.stub().returns(this.currentAlertSession),
+      getAlertSessionByPhoneNumbers: sandbox.stub().returns(this.currentAlertSession),
       alertSessionChangedCallback: sandbox.stub().returns(responderPhoneNumber),
     })
 

--- a/test/integration/testHappyPathTwilio.js
+++ b/test/integration/testHappyPathTwilio.js
@@ -53,7 +53,7 @@ describe('happy path Twilio integration test: responder responds right away and 
 
     this.braveAlerter = testingHelpers.braveAlerterFactory({
       getAlertSession: sandbox.stub().returns(this.currentAlertSession),
-      getAlertSessionByPhoneNumber: sandbox.stub().returns(this.currentAlertSession),
+      getAlertSessionByPhoneNumbers: sandbox.stub().returns(this.currentAlertSession),
       alertSessionChangedCallback: sandbox.stub().returns(responderPhoneNumber),
     })
 

--- a/test/testingHelpers.js
+++ b/test/testingHelpers.js
@@ -7,8 +7,8 @@ function dummyGetAlertSession() {
   return 'getAlertSession'
 }
 
-function dummyGetAlertSessionByPhoneNumber() {
-  return 'getAlertSessionByPhoneNumber'
+function dummyGetAlertSessionByPhoneNumbers() {
+  return 'getAlertSessionByPhoneNumbers'
 }
 
 function dummyGetAlertSessionBySessionIdAndAlertApiKey() {
@@ -47,7 +47,7 @@ function braveAlerterFactory(overrides = {}) {
   // prettier-ignore
   return new BraveAlerter(
     overrides.getAlertSession !== undefined ? overrides.getAlertSession : dummyGetAlertSession,
-    overrides.getAlertSessionByPhoneNumber !== undefined ? overrides.getAlertSessionByPhoneNumber : dummyGetAlertSessionByPhoneNumber,
+    overrides.getAlertSessionByPhoneNumbers !== undefined ? overrides.getAlertSessionByPhoneNumbers : dummyGetAlertSessionByPhoneNumbers,
     overrides.getAlertSessionBySessionIdAndAlertApiKey !== undefined ? overrides.getAlertSessionBySessionIdAndAlertApiKey : dummyGetAlertSessionBySessionIdAndAlertApiKey,
     overrides.alertSessionChangedCallback !== undefined ? overrides.alertSessionChangedCallback : dummyAlertSessionChangedCallback,
     overrides.getLocationByAlertApiKey !== undefined ? overrides.getLocationByAlertApiKey : dummyGetLocationByAlertApiKey,

--- a/test/unit/testBraveAlerter/testBraveAlerterContructor.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterContructor.js
@@ -9,8 +9,8 @@ function dummyGetAlertSession() {
   return 'getAlertSession'
 }
 
-function dummyGetAlertSessionByPhoneNumber() {
-  return 'getAlertSessionByPhoneNumber'
+function dummyGetAlertSessionByPhoneNumbers() {
+  return 'getAlertSessionByPhoneNumbers'
 }
 
 function dummyGetAlertSessionBySessionIdAndAlertApiKey() {
@@ -52,7 +52,7 @@ describe('braveAlerter.js unit tests: constructor', () => {
 
     this.braveAlerter = new BraveAlerter(
       dummyGetAlertSession,
-      dummyGetAlertSessionByPhoneNumber,
+      dummyGetAlertSessionByPhoneNumbers,
       dummyGetAlertSessionBySessionIdAndAlertApiKey,
       dummyAlertSessionChangedCallback,
       dummyGetLocationByAlertApiKey,
@@ -71,7 +71,7 @@ describe('braveAlerter.js unit tests: constructor', () => {
   it('should be able to call the functions set by in the constructor', () => {
     const result = `
       ${this.braveAlerter.getAlertSession()}
-      ${this.braveAlerter.getAlertSessionByPhoneNumber()}
+      ${this.braveAlerter.getAlertSessionByPhoneNumbers()}
       ${this.braveAlerter.getAlertSessionBySessionIdAndAlertApiKey()}
       ${this.braveAlerter.alertSessionChangedCallback()}
       ${this.braveAlerter.getLocationByAlertApiKey()}
@@ -85,7 +85,7 @@ describe('braveAlerter.js unit tests: constructor', () => {
     expect(result).to.equal(
       `
       getAlertSession
-      getAlertSessionByPhoneNumber
+      getAlertSessionByPhoneNumbers
       getAlertSessionBySessionIdAndAlertApiKey
       alertSessionChangedCallback
       getLocationByAlertApiKey

--- a/test/unit/testBraveAlerter/testBraveAlerterHandleTwilioRequest.js
+++ b/test/unit/testBraveAlerter/testBraveAlerterHandleTwilioRequest.js
@@ -44,7 +44,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
           // Don't actually call braveAlerter methods
           this.braveAlerter = testingHelpers.braveAlerterFactory({
             alertSessionChangedCallback: sandbox.stub().returns(this.responderPhoneNumber),
-            getAlertSessionByPhoneNumber: sinon.stub().returns(
+            getAlertSessionByPhoneNumbers: sinon.stub().returns(
               testingHelpers.alertSessionFactory({
                 sessionId: 'guid-123',
                 alertState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
@@ -116,7 +116,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
           // Don't actually call braveAlerter methods
           this.braveAlerter = testingHelpers.braveAlerterFactory({
             alertSessionChangedCallback: sandbox.stub().returns(this.responderPhoneNumber),
-            getAlertSessionByPhoneNumber: sinon.stub().returns(
+            getAlertSessionByPhoneNumbers: sinon.stub().returns(
               testingHelpers.alertSessionFactory({
                 sessionId: 'guid-123',
                 alertState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
@@ -160,13 +160,14 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
       describe('and the request is not from a responder phone', () => {
         beforeEach(async () => {
           this.invalidFromNumber = 'not +11231231234'
+          this.toNumber = '+11231231234'
           this.guid = 'guid-123'
 
           const invalidRequest = {
             path: '/alert/sms',
             body: {
               From: this.invalidFromNumber,
-              To: '+11231231234',
+              To: this.toNumber,
               Body: 'fake body',
             },
           }
@@ -176,16 +177,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
           // Don't actually call braveAlerter methods
           this.braveAlerter = testingHelpers.braveAlerterFactory({
             alertSessionChangedCallback: sandbox.stub(),
-            getAlertSessionByPhoneNumber: sinon.stub().returns(
-              testingHelpers.alertSessionFactory({
-                sessionId: this.guid,
-                alertState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
-                incidentCategoryKey: '3',
-                responderPhoneNumbers: ['+11231231234'],
-                validIncidentCategoryKeys: ['3'],
-                validIncidentCategories: ['three'],
-              }),
-            ),
+            getAlertSessionByPhoneNumbers: sinon.stub().returns(null),
           })
           sandbox.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
             nextAlertState: CHATBOT_STATE.COMPLETED,
@@ -201,13 +193,13 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
         })
 
         it('should log the error', () => {
-          expect(helpers.logError).to.be.calledWith(
-            `Bad request to /alert/sms: ${this.invalidFromNumber} is not the responder phone for ${this.guid}`,
+          expect(helpers.log).to.be.calledWith(
+            `Received twilio message from ${this.invalidFromNumber} to ${this.toNumber} with no corresponding open session`,
           )
         })
 
-        it('should return 400', () => {
-          expect(this.fakeExpressResponse.status).to.be.calledWith(400)
+        it('should return 200', () => {
+          expect(this.fakeExpressResponse.status).to.be.calledWith(200)
         })
       })
     })
@@ -231,7 +223,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
 
         // Don't actually call braveAlerter methods
         this.braveAlerter = testingHelpers.braveAlerterFactory({
-          getAlertSessionByPhoneNumber: sandbox.stub().returns(null),
+          getAlertSessionByPhoneNumbers: sandbox.stub().returns(null),
           alertSessionChangedCallback: sandbox.stub(),
         })
         sandbox.stub(this.braveAlerter.alertStateMachine, 'processStateTransitionWithMessage').returns({
@@ -272,7 +264,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
       // Don't actually call braveAlerter methods
       this.braveAlerter = testingHelpers.braveAlerterFactory({
         alertSessionChangedCallback: sandbox.stub(),
-        getAlertSessionByPhoneNumber: sinon.stub().returns(
+        getAlertSessionByPhoneNumbers: sinon.stub().returns(
           testingHelpers.alertSessionFactory({
             sessionId: 'guid-123',
             alertState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
@@ -319,7 +311,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
       // Don't actually call braveAlerter methods
       this.braveAlerter = testingHelpers.braveAlerterFactory({
         alertSessionChangedCallback: sandbox.stub(),
-        getAlertSessionByPhoneNumber: sinon.stub().returns(
+        getAlertSessionByPhoneNumbers: sinon.stub().returns(
           testingHelpers.alertSessionFactory({
             sessionId: 'guid-123',
             alertState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
@@ -366,7 +358,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
       // Don't actually call braveAlerter methods
       this.braveAlerter = testingHelpers.braveAlerterFactory({
         alertSessionChangedCallback: sandbox.stub(),
-        getAlertSessionByPhoneNumber: sinon.stub().returns(
+        getAlertSessionByPhoneNumbers: sinon.stub().returns(
           testingHelpers.alertSessionFactory({
             sessionId: 'guid-123',
             alertState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
@@ -416,7 +408,7 @@ describe('braveAlerter.js unit tests: handleTwilioRequest', () => {
       // Don't actually call braveAlerter methods
       this.braveAlerter = testingHelpers.braveAlerterFactory({
         alertSessionChangedCallback: sandbox.stub(),
-        getAlertSessionByPhoneNumber: sinon.stub().returns(
+        getAlertSessionByPhoneNumbers: sinon.stub().returns(
           testingHelpers.alertSessionFactory({
             sessionId: 'guid-123',
             alertState: CHATBOT_STATE.WAITING_FOR_CATEGORY,


### PR DESCRIPTION
... to take both the fromPhoneNumber and toPhoneNumber so that we
can find the session with that devicePhoneNumber and
responderPhoneNumber. This will allow us to re-use Twilio numbers
at different clients (assuming the clients have different
responderPhoneNumbers)

## Test Plan
- :heavy_check_mark: Passes all the tests in the corresponding Sensors pull request: https://github.com/bravetechnologycoop/BraveSensor/pull/177
- :heavy_check_mark: Passes all the tests in the corresponding Buttons pull request: https://github.com/bravetechnologycoop/BraveButtons/pull/170