### PR TITLE
Improve error messages when buying Twilio numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved error messages when buying Twilio phone numbers.
+
 ## [9.0.0] - 2022-07-21
 
 ### Changed

--- a/lib/twilioHelpers.js
+++ b/lib/twilioHelpers.js
@@ -66,7 +66,7 @@ async function buyAndConfigureTwilioPhoneNumber(areaCode, friendlyName) {
     }
   } catch (err) {
     helpers.logError(err)
-    return { message: 'Error in Purchasing Twilio Number' }
+    return { message: err.toString() }
   }
 }
 

--- a/lib/twilioHelpers.js
+++ b/lib/twilioHelpers.js
@@ -65,7 +65,7 @@ async function buyAndConfigureTwilioPhoneNumber(areaCode, friendlyName) {
       }
     }
   } catch (err) {
-    helpers.logError(err)
+    helpers.log(err)
     return { message: err.toString() }
   }
 }

--- a/test/integration/testTwilioHelpers.js
+++ b/test/integration/testTwilioHelpers.js
@@ -66,7 +66,7 @@ describe('twilioHelpers.js integration tests:', () => {
       })
 
       it('should return an error object', async () => {
-        expect(this.response).to.eql({ message: 'Error in Purchasing Twilio Number' })
+        expect(this.response).to.eql({ message: 'Error: No phone numbers found' })
       })
 
       it('should log the error', async () => {

--- a/test/integration/testTwilioHelpers.js
+++ b/test/integration/testTwilioHelpers.js
@@ -70,7 +70,7 @@ describe('twilioHelpers.js integration tests:', () => {
       })
 
       it('should log the error', async () => {
-        expect(helpers.logError).to.be.called
+        expect(helpers.log).to.be.called
       })
     })
   })

--- a/test/unit/testTwilioHelpers/testBuyAndConfigureTwilioPhoneNumber.js
+++ b/test/unit/testTwilioHelpers/testBuyAndConfigureTwilioPhoneNumber.js
@@ -168,7 +168,7 @@ describe('twilioHelpers.js unit tests: buyAndConfigureTwilioPhoneNumber', () => 
 
     it('should return a error object', () => {
       expect(this.response).to.eql({
-        message: 'Error in Purchasing Twilio Number',
+        message: 'Error',
       })
     })
 

--- a/test/unit/testTwilioHelpers/testBuyAndConfigureTwilioPhoneNumber.js
+++ b/test/unit/testTwilioHelpers/testBuyAndConfigureTwilioPhoneNumber.js
@@ -172,12 +172,12 @@ describe('twilioHelpers.js unit tests: buyAndConfigureTwilioPhoneNumber', () => 
       })
     })
 
-    it('should not log anything', () => {
-      expect(helpers.log).not.to.be.called
+    it('should log the errors anything', () => {
+      expect(helpers.log).to.be.called
     })
 
-    it('should log the errors', () => {
-      expect(helpers.logError).to.be.called
+    it('should log any errors', () => {
+      expect(helpers.logError).not.to.be.called
     })
   })
 })


### PR DESCRIPTION
- It was really annoying not to know why this function failed. We
  would have to look into the server logs to find out, this info
  is better sent back to the client who can display it in the UI

## Test Plan
- :heavy_check_mark: Deploy to Sensors dev
- :heavy_check_mark: Hit the endpoint with an area code that has no available phone numbers (try 600). See error message that says "Error: No phone numbers found"
- :heavy_check_mark: Hit the endpoint with an area code that doesn't exist but is formatted correctly (try 000). See error message that says "Error: Invalid local area code: 000"
- :heavy_check_mark: Hit the endpoint with an area code that isn't formatted correctly (try abc). See error message that syas "Error: Invalid area code: abc"
- :heavy_check_mark: Do not log any of these errors to Sentry