### PR TITLE
Split Client is_active into is_displayed, is_sending_alerts, is_sending_vitals (CU-860q154rh, CU-860ptt5rp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Broke up the Client's `is_active` field into the component parts: `is_displayed`, `is_sending_alerts`, and `is_sending_vitals` (CU-860ptt5rp, CU-860q154rh).
+
 ## [9.3.0] - 2023-02-07
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -367,7 +367,11 @@ An object representing a client. Contains the following fields:
 
 **incidentCategories (array of strings):** Array of incident categories the Client's responder will be asked to choose from for each alert; should be the database value `client.incident_categories`
 
-**isActive (boolean):** If this Client is currently active (can be used for things like hiding on the Dashboard and not sending out vitals/heartbeat messages); should be the database value `client.is_active`
+**isDisplayed (boolean):** If this Client is displayed on the dashboard by default; should be the database value `client.is_displayed`
+
+**isSendingAlerts (boolean):** If this Client should send alert messages; should be the database value `client.is_sending_alerts`
+
+**isSendingVitals (boolean):** If this Client is should send vitals messages; should be the database value `client.is_sending_vitals`
 
 **createdAt (Date):** When the Client was created in the database; should be the database value `client.created_at`
 

--- a/lib/models/Client.js
+++ b/lib/models/Client.js
@@ -11,7 +11,9 @@ class Client {
     fallbackTimeout,
     heartbeatPhoneNumbers,
     incidentCategories,
-    isActive,
+    isDisplayed,
+    isSendingAlerts,
+    isSendingVitals,
     language,
     createdAt,
     updatedAt,
@@ -27,7 +29,9 @@ class Client {
     this.fallbackTimeout = fallbackTimeout
     this.heartbeatPhoneNumbers = heartbeatPhoneNumbers
     this.incidentCategories = incidentCategories
-    this.isActive = isActive
+    this.isDisplayed = isDisplayed
+    this.isSendingAlerts = isSendingAlerts
+    this.isSendingVitals = isSendingVitals
     this.language = language
     this.createdAt = createdAt
     this.updatedAt = updatedAt

--- a/lib/models/factories.js
+++ b/lib/models/factories.js
@@ -12,7 +12,9 @@ async function clientDBFactory(db, overrides = {}) {
     overrides.fallbackTimeout !== undefined ? overrides.fallbackTimeout : 2,
     overrides.heartbeatPhoneNumbers !== undefined ? overrides.heartbeatPhoneNumbers : ['+18889997777'],
     overrides.incidentCategories !== undefined ? overrides.incidentCategories : ['Accidental', 'Safer Use', 'Unsafe Guest', 'Overdose', 'Other'],
-    overrides.isActive !== undefined ? overrides.isActive : true,
+    overrides.isDisplayed !== undefined ? overrides.isDisplayed : true,
+    overrides.isSendingAlerts !== undefined ? overrides.isSendingAlerts : true,
+    overrides.isSendingVitals !== undefined ? overrides.isSendingVitals : true,
     overrides.language !== undefined ? overrides.language : 'en',
   )
 
@@ -32,7 +34,9 @@ function clientFactory(overrides = {}) {
     overrides.fallbackTimeout !== undefined ? overrides.fallbackTimeout : 2,
     overrides.heartbeatPhoneNumbers !== undefined ? overrides.heartbeatPhoneNumbers : ['+18889997777'],
     overrides.incidentCategories !== undefined ? overrides.incidentCategories : ['Accidental', 'Safer Use', 'Unsafe Guest', 'Overdose', 'Other'],
-    overrides.isActive !== undefined ? overrides.isActive : true,
+    overrides.isDisplayed !== undefined ? overrides.isDisplayed : true,
+    overrides.isSendingAlerts !== undefined ? overrides.isSendingAlerts : true,
+    overrides.isSendingVitals !== undefined ? overrides.isSendingVitals : true,
     overrides.language !== undefined ? overrides.language : 'en',
     overrides.createdAt !== undefined ? overrides.createdAt : new Date('2021-11-04T22:28:28.0248Z'),
     overrides.updatedAt !== undefined ? overrides.updatedAt : new Date('2021-11-05T02:02:22.234Z'),


### PR DESCRIPTION
- This gives us more fine-grained control over the messages and the display properties of the clients

## Test plan
- [x] Deploy to Buttons Dev
- [x] Passes tests in https://github.com/bravetechnologycoop/BraveButtons/pull/190