### PR TITLE
Fixed usage of Date.now() for paGetPayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - clickUpHelpers in favour of googleHelpers (CU-86791h7nu).
 
+### Fixed
+
+- Usage of Date.now() with respect to the expiration date in Google ID tokens (CU-86791h7nu).
+
 ## [10.2.0] - 2023-09-28
 
 ### Security

--- a/lib/googleHelpers.js
+++ b/lib/googleHelpers.js
@@ -19,8 +19,10 @@ async function paGetPayload(googleIdToken) {
   const ticket = await paOAuth2Client.verifyIdToken({ idToken: googleIdToken })
   const payload = ticket.getPayload()
 
+  /* NOTE: Date.now() is in milliseconds, whereas payload.exp is in seconds.
+   * This is why Date.now() is divided by 1000; so that it is in seconds. */
   if (
-    Date.now() > payload.exp ||
+    Date.now() / 1000 > payload.exp ||
     payload.aud !== PA_CLIENT_ID ||
     (payload.iss !== 'https://accounts.google.com' && payload.iss !== 'accounts.google.com') ||
     payload.hd !== PA_GSUITE_DOMAIN ||

--- a/test/testingHelpers.js
+++ b/test/testingHelpers.js
@@ -105,7 +105,7 @@ function mockGoogleIdTokenFactory(options) {
     aud: options.validAudience ? googleHelpers.__get__('PA_CLIENT_ID') : 'not-pa',
     iss: options.validSignature ? 'https://accounts.google.com' : 'hacker.com',
     // either expires in 1 hour, or expired 1 hour ago
-    exp: options.validExpiry ? Date.now() + 3600 : Date.now() - 3600,
+    exp: options.validExpiry ? Date.now() / 1000 + 3600 : Date.now() / 1000 - 3600,
     // eslint-disable-next-line no-underscore-dangle
     hd: options.validProfile ? googleHelpers.__get__('PA_GSUITE_DOMAIN') : undefined,
     // eslint-disable-next-line no-underscore-dangle
@@ -133,7 +133,7 @@ const mockOAuth2Client = {
     }
 
     // replicates error thrown by Google's OAuth2Client for an expired token
-    if (Date.now() > payload.exp) {
+    if (Date.now() / 1000 > payload.exp) {
       throw new Error(`Token used too late, ${Date.now()} > ${payload.exp}: ${JSON.stringify(payload)}`)
     }
 


### PR DESCRIPTION
This is a minor error that arose when testing the library with real Google ID tokens.

I had not realized that the `Date.now()` function returns the UNIX epoch time in *milliseconds*, whereas the `exp` member of a Google ID token is a UNIX epoch time in *seconds*.
Thus, when using `paGetPayload` on a real Google ID token, `Date.now()` always evaluated to be greater than the `exp` member of a Google ID token; e.g., 123456789000 > 123456789.

This PR updates the usage of `Date.now()` such that it is divided by 1000 to be in seconds, not milliseconds.
It also updates the usage of `Date.now()` in the mock OAuth2Client object and Google ID token factory defined in `testingHelpers.js`. 

Test plan:
- [x] Passes all previously created tests for `googleHelpers`.