### PR TITLE
Fixed response of googleHelpers.paAuthorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Response of googleHelpers.paAuthorize to properly send information if an error occurred.
+
+### Security
+
+- Upgraded axios from 0.21.4 to 1.6.0.
+
 ## [10.3.0] - 2023-11-14
 
 ### Added

--- a/lib/googleHelpers.js
+++ b/lib/googleHelpers.js
@@ -58,16 +58,16 @@ async function paGetTokens(googleAuthCode) {
 async function paAuthorize(req, res, next) {
   try {
     if (!req.body.googleIdToken) {
-      helpers.log(`PA: Not authorized: ${req.path}`)
-      res.status(400) // Bad Request
+      helpers.log(`PA: Bad request to ${req.path}`)
+      res.status(400).send({ message: 'Bad request' })
     } else {
       // paGetPayload also validates a Google ID token; it will throw an Error if an invalid Google ID token is given */
       await paGetPayload(req.body.googleIdToken)
       next() // perform next action
     }
   } catch (error) {
-    helpers.log(`PA: Not authorized: ${req.path}`)
-    res.status(401) // Unauthorized
+    helpers.log(`PA: Unauthorized request to ${req.path}`)
+    res.status(401).send({ message: 'Unauthorized' })
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
-        "axios": "^0.21.2",
+        "axios": "^1.6.0",
         "chalk": "^4.1.0",
         "dotenv": "^7.0.0",
         "express": "^4.17.1",
@@ -1390,8 +1390,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -1415,11 +1414,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1813,7 +1814,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2001,7 +2001,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3027,7 +3026,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5431,6 +5429,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
-    "axios": "^0.21.2",
+    "axios": "^1.6.0",
     "chalk": "^4.1.0",
     "dotenv": "^7.0.0",
     "express": "^4.17.1",


### PR DESCRIPTION
In the event of error, the response object is never closed, because it does not end with a '.send()', '.json()', or '.end()'. This fixes that.

Additionally, axios is upgraded to resolve a node security vulnerability.

Test plan:
- [x] Existing test cases pass.
- [ ] Dependant repositories (BraveSensor, BraveButtons) have correct functionality for PA API calls.