### PR TITLE
Bug fix for googleHelpers.paAuthorize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Response of googleHelpers.paAuthorize to resolve in the event of a bad or unauthorized request.
+
 ## [10.3.0] - 2023-11-14
 
 ### Added

--- a/lib/googleHelpers.js
+++ b/lib/googleHelpers.js
@@ -59,7 +59,7 @@ async function paAuthorize(req, res, next) {
   try {
     if (!req.body.googleIdToken) {
       helpers.log(`PA: Not authorized: ${req.path}`)
-      res.status(400) // Bad Request
+      res.status(400).send({ message: 'Bad request' })
     } else {
       // paGetPayload also validates a Google ID token; it will throw an Error if an invalid Google ID token is given */
       await paGetPayload(req.body.googleIdToken)
@@ -67,7 +67,7 @@ async function paAuthorize(req, res, next) {
     }
   } catch (error) {
     helpers.log(`PA: Not authorized: ${req.path}`)
-    res.status(401) // Unauthorized
+    res.status(401).send({ message: 'Unauthorized' })
   }
 }
 


### PR DESCRIPTION
In the event of an error in googleHelpers.paAuthorize, the response object is never closed / resolved.
This is because it does not end with a '.send()', '.json()', or '.end()'; just 'res.status(401)' or 'res.status(400)'.

This PR fixes that, returning a JSON message giving a brief explanation of the error; 'Unauthorized' or 'Bad request'.

Test plan:
- [x] Existing test cases pass.
- [x] Dependant repositories (BraveSensor, BraveButtons) have correct functionality for PA API calls.
- [x] Unauthorized requests from PA (deployed to dev.pa.brave.coop) resolve, and aren't stuck in waiting.