### PR TITLE
Remove alertApiKey and responderPushId from Client model and factory functions (CU-86dqkmhza).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - OneSignal code: ActiveAlert, HistoricAlert, Location, SYSTEM, and respective functionality in BraveAlerter (CU-86dqkmhza).
+- OneSignal remnants in the Client class and respective factory functions (CU-86dqkmhza).
 
 ## [11.0.1] - 2023-12-01
 

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ Updates an ongoing alert session.
 
 **sessionId (GUID):** Unique identifier for the alert session that was updated; this should match the session ID in the DB
 
-**toPhoneNumbers (array of strings):** The phone numbers to send text message alert to if `responderPushId` is `undefined`.
+**toPhoneNumbers (array of strings):** The phone numbers to send text message alerts to.
 
-**fromPhoneNumber (string):** The phone number to send text message alert from if `responderPushId` is `undefined`.
+**fromPhoneNumber (string):** The phone number to send text message alerts from.
 
 **textMessage (string):** Message containing the update to be sent over SMS.
 
@@ -166,9 +166,9 @@ Starts a full alert session configured with the given `alertInfo` object.
 
 **alertInfo.sessionId (GUID):** Unique identifier for the session; this should match the session ID in the DB
 
-**alertInfo.toPhoneNumbers (string):** The phone numbers to send text message alert to if `alertInfo.responderPushId` is `undefined`.
+**alertInfo.toPhoneNumbers (string):** The phone numbers to send text message alerts to.
 
-**alertInfo.fromPhoneNumber (string):** The phone number to send text message alert from if `alertInfo.responderPushId` is `undefined`.
+**alertInfo.fromPhoneNumber (string):** The phone number to send text message alerts from.
 
 **alertInfo.message (string):** First message to send as part of this session
 
@@ -232,10 +232,6 @@ An object representing a client. Contains the following fields:
 **displayName (string):** Client name is a displayable format; should be the database value `client.display_name`
 
 **responderPhoneNumbers (array of string):** Client's responder phone numbers in the form `+133344455555`; should be the database value `client.responder_phone_numbers`
-
-**responderPushId (string):** Client's Alert App Responder Push ID; should be the database value `client.responder_push_id`
-
-**alertApiKey (string):** Client's Alert App API Key; should be the database value `client.alert_api_key`
 
 **reminderTimeout (int):** Number of seconds after the initial alert before a reminder is sent; should be the database value `client.reminder_timeout`
 

--- a/lib/models/Client.js
+++ b/lib/models/Client.js
@@ -3,8 +3,6 @@ class Client {
     id,
     displayName,
     responderPhoneNumbers,
-    responderPushId,
-    alertApiKey,
     reminderTimeout,
     fallbackPhoneNumbers,
     fromPhoneNumber,
@@ -21,8 +19,6 @@ class Client {
     this.id = id
     this.displayName = displayName
     this.responderPhoneNumbers = responderPhoneNumbers
-    this.responderPushId = responderPushId
-    this.alertApiKey = alertApiKey
     this.reminderTimeout = reminderTimeout
     this.fallbackPhoneNumbers = fallbackPhoneNumbers
     this.fromPhoneNumber = fromPhoneNumber

--- a/lib/models/factories.js
+++ b/lib/models/factories.js
@@ -4,8 +4,6 @@ async function clientDBFactory(db, overrides = {}) {
   const client = await db.createClient(
     overrides.displayName !== undefined ? overrides.displayName : 'fakeLocationName',
     overrides.responderPhoneNumbers !== undefined ? overrides.responderPhoneNumbers : ['+17781234567'],
-    overrides.responderPushId !== undefined ? overrides.responderPushId : 'myPushId',
-    overrides.alertApiKey !== undefined ? overrides.alertApiKey : 'alertApiKey',
     overrides.reminderTimeout !== undefined ? overrides.reminderTimeout : 1,
     overrides.fallbackPhoneNumbers !== undefined ? overrides.fallbackPhoneNumbers : ['+13336669999'],
     overrides.fromPhoneNumber !== undefined ? overrides.fromPhoneNumber : '+15005550006',
@@ -26,8 +24,6 @@ function clientFactory(overrides = {}) {
     overrides.id !== undefined ? overrides.id : 'fakeLocationid',
     overrides.displayName !== undefined ? overrides.displayName : 'fakeLocationName',
     overrides.responderPhoneNumbers !== undefined ? overrides.responderPhoneNumbers : ['+17781234567'],
-    overrides.responderPushId !== undefined ? overrides.responderPushId : 'myPushId',
-    overrides.alertApiKey !== undefined ? overrides.alertApiKey : 'alertApiKey',
     overrides.reminderTimeout !== undefined ? overrides.reminderTimeout : 1,
     overrides.fallbackPhoneNumbers !== undefined ? overrides.fallbackPhoneNumbers : ['+13336669999'],
     overrides.fromPhoneNumber !== undefined ? overrides.fromPhoneNumber : '+15005550006',


### PR DESCRIPTION
This is a continuation of the previously merged [PR](https://github.com/bravetechnologycoop/brave-alert-lib/pull/67), which removes much of the OneSignal code in brave-alert-lib.