### PR TITLE
Add Session model (CU-86791yyvg).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Session class to models (CU-86791yyvg).
+
 ## [12.1.1] - 2024-01-04
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const Client = require('./lib/models/Client')
 const factories = require('./lib/models/factories')
 const googleHelpers = require('./lib/googleHelpers')
 const helpers = require('./lib/helpers')
+const Session = require('./lib/models/Session')
 const twilioHelpers = require('./lib/twilioHelpers')
 
 module.exports = {
@@ -17,5 +18,6 @@ module.exports = {
   factories,
   googleHelpers,
   helpers,
+  Session,
   twilioHelpers,
 }

--- a/lib/models/Session.js
+++ b/lib/models/Session.js
@@ -1,0 +1,28 @@
+const ALERT_TYPE = require('../alertTypeEnum')
+
+class Session {
+  // prettier-ignore
+  constructor(id, chatbotState, alertType, numberOfAlerts, createdAt, updatedAt, incidentCategory, respondedAt, respondedByPhoneNumber, device) {
+    this.id = id
+    this.chatbotState = chatbotState
+    this.alertType = alertType
+    this.numberOfAlerts = numberOfAlerts
+    this.createdAt = createdAt
+    this.updatedAt = updatedAt
+    this.incidentCategory = incidentCategory
+    this.respondedAt = respondedAt
+    this.respondedByPhoneNumber = respondedByPhoneNumber
+
+    // this is temporary: change these two lines to `this.device = device` when renaming buttons and locations table to devices table in both buttons and sensor
+    this.button = device
+    this.location = device
+  }
+
+  // this is specific to buttons: notice that this.alertType is updated
+  incrementButtonPresses(numberOfAlerts) {
+    this.numberOfAlerts += numberOfAlerts
+    this.alertType = ALERT_TYPE.BUTTONS_URGENT
+  }
+}
+
+module.exports = Session


### PR DESCRIPTION
This PR moves the Session model from BraveButtons and BraveSensor into brave-alert-lib, by combining and aggregating parts from both. It should work as a drop-in replacement for the versions currently implemented in either repositories.