### PR TITLE
Authorize with Authorization header (of type Bearer) for googleHelpers.paAuthorize (CU-13kqjz8).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `paAuthorize` function of `googleHelpers` to also authorize with Authorization header of type Bearer (CU-13kqjz8).
+- `Session` class model to deprecate the `incrementButtonPresses` function (CU-13kqjz8).
 
 ## [12.2.0] - 2024-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `paAuthorize` function of `googleHelpers` to also authorize with Authorization header of type Bearer (CU-13kqjz8).
+
 ## [12.2.0] - 2024-01-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -458,10 +458,10 @@ If the authorization code is invalid, then this function will throw a `GaxiosErr
 ### paAuthorize(req, res, next)
 
 Express middleware function to authorize a request to a PA API call.
-Attempts to authorize the request using a submitted Google ID token in the body of the request.
+Attempts to authorize the request using a submitted Google ID token in the Authorization header or body of the request.
 The criteria for a valid Google ID token is defined under the `paGetPayload` function.
 
-**req (Request):** The Express Request object. Should contain googleIdToken in the body of the request.
+**req (Request):** The Express Request object. Should contain googleIdToken in the Authorization header or body of the request.
 
 **res (Response):** The Express Response object.
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,28 @@ An object representing a client. Contains the following fields:
 
 **updatedAt (Date):** When the Client was last updated in the database; should be the database value `client.updated_at`
 
+## `Session` class
+
+An object representing a session. Contains the following fields:
+
+**id (GUID):** Unique identifier of the session; should be the database value `session.id`
+
+**chatbotState (CHATBOT_STATE enum):** The chatbot state of the session; should be the database value `session.chatbot_state`
+
+**alertType (ALERT_TYPE enum):** The alert type of the session; should be the database value `session.alert_type`
+
+**numberOfAlerts (int):** The number of alerts sent during the session; should be the database value `session.number_of_alerts`
+
+**createdAt (Date):** When the Session was created in the database; should be the database value `session.created_at`
+
+**updatedAt (Date):** When the Session was last updated in the database; should be the database value `session.updated_at`
+
+**incidentCategory (string):** The chosen incident category of the session; should be the database value `session.incident_category`
+
+**respondedAt (Date):** When the Session was responded to; should be the database value `session.responded_at`
+
+**respondedByPhoneNumber (string):** The phone number of the responder that replied to the alert this session describes; should be the database value `session.responded_by_phone_number`
+
 ## `ALERT_TYPE` enum
 
 An enum of the possible types of alert that can be triggered.

--- a/lib/googleHelpers.js
+++ b/lib/googleHelpers.js
@@ -29,7 +29,7 @@ async function paGetPayload(googleIdToken) {
     !payload.email ||
     !payload.name
   ) {
-    throw new Error('Token is not valid')
+    throw new Error('Invalid Google ID Token')
   }
 
   return payload
@@ -50,23 +50,38 @@ async function paGetTokens(googleAuthCode) {
 
 /**
  * Express middleware function to authorize a request to a PA API call.
- * Attempts to authorize the request using a submitted Google ID token in the body of the request.
- * @param req The Express Request object. Should contain googleIdToken in the body of the request.
+ * Attempts to authorize the request using a submitted Google ID token contained either in the Authorization header or the body of the request.
+ * @param req The Express Request object. Should contain googleIdToken in the Authorization header or body of the request.
  * @param res The Express Response object.
  * @param next The next function to run if this request is authorized.
  */
 async function paAuthorize(req, res, next) {
   try {
-    if (!req.body.googleIdToken) {
-      helpers.log(`PA: Not authorized: ${req.path}`)
-      res.status(400).send({ message: 'Bad request' })
-    } else {
-      // paGetPayload also validates a Google ID token; it will throw an Error if an invalid Google ID token is given */
-      await paGetPayload(req.body.googleIdToken)
-      next() // perform next action
+    let googleIdToken // starts undefined
+
+    if (req.get && req.get('Authorization')) {
+      // Google ID Token is contained in the Authorization header
+      const authorization = req.get('Authorization')
+
+      if (authorization.startsWith('Bearer')) {
+        // the Google ID Token starts after 'Bearer' and a space
+        googleIdToken = authorization.slice(7)
+      }
+    } else if (req.body && req.body.googleIdToken) {
+      // Google ID Token is contained in the body
+      googleIdToken = req.body.googleIdToken
     }
+
+    // no Google ID Token was provided
+    if (googleIdToken === undefined) {
+      throw new Error('Missing Google ID Token')
+    }
+
+    // paGetPayload also validates a Google ID token; it will throw an Error if an invalid Google ID token is given
+    await paGetPayload(googleIdToken)
+    next() // perform next action; no error was thrown
   } catch (error) {
-    helpers.log(`PA: Not authorized: ${req.path}`)
+    helpers.log(`Google OAuth2: Unauthorized request to ${req.path}: ${error.message}`)
     res.status(401).send({ message: 'Unauthorized' })
   }
 }

--- a/lib/models/Session.js
+++ b/lib/models/Session.js
@@ -1,5 +1,3 @@
-const ALERT_TYPE = require('../alertTypeEnum')
-
 class Session {
   // prettier-ignore
   constructor(id, chatbotState, alertType, numberOfAlerts, createdAt, updatedAt, incidentCategory, respondedAt, respondedByPhoneNumber, device) {
@@ -16,12 +14,6 @@ class Session {
     // this is temporary: change these two lines to `this.device = device` when renaming buttons and locations table to devices table in both buttons and sensor
     this.button = device
     this.location = device
-  }
-
-  // this is specific to buttons: notice that this.alertType is updated
-  incrementButtonPresses(numberOfAlerts) {
-    this.numberOfAlerts += numberOfAlerts
-    this.alertType = ALERT_TYPE.BUTTONS_URGENT
   }
 }
 

--- a/test/testingHelpers.js
+++ b/test/testingHelpers.js
@@ -114,7 +114,7 @@ const mockOAuth2Client = {
 
     // replicates error thrown by Google's OAuth2Client for an expired token
     if (Date.now() / 1000 > payload.exp) {
-      throw new Error(`Token used too late, ${Date.now()} > ${payload.exp}: ${JSON.stringify(payload)}`)
+      throw new Error(`Token used too late, ${Date.now() / 1000} > ${payload.exp}: ${JSON.stringify(payload)}`)
     }
 
     // return an Object implementing the getPayload method similar to Google's Ticket class

--- a/test/testingHelpers.js
+++ b/test/testingHelpers.js
@@ -112,9 +112,8 @@ const mockOAuth2Client = {
       throw new Error("Couldn't parse token")
     }
 
-    // replicates error thrown by Google's OAuth2Client for an expired token
     if (Date.now() / 1000 > payload.exp) {
-      throw new Error(`Token used too late, ${Date.now() / 1000} > ${payload.exp}: ${JSON.stringify(payload)}`)
+      throw new Error('Token used too late')
     }
 
     // return an Object implementing the getPayload method similar to Google's Ticket class

--- a/test/unit/testGoogleHelpers/testPaAuthorize.js
+++ b/test/unit/testGoogleHelpers/testPaAuthorize.js
@@ -132,10 +132,7 @@ describe('googleHelpers.js unit tests: paAuthorize', () => {
     })
 
     it('should log the unauthorized request', () => {
-      const now = Date.now() / 1000
-      const errorMessage = `Token used too late, ${now} > ${now - 3600}: ${this.googleIdToken}`
-
-      expect(helpers.log).to.be.calledWith(`Google OAuth2: Unauthorized request to ${TEST_PATH}: ${errorMessage}`)
+      expect(helpers.log).to.be.calledWith(`Google OAuth2: Unauthorized request to ${TEST_PATH}: Token used too late`)
     })
   })
 

--- a/test/unit/testGoogleHelpers/testPaAuthorize.js
+++ b/test/unit/testGoogleHelpers/testPaAuthorize.js
@@ -31,7 +31,7 @@ describe('googleHelpers.js unit tests: paAuthorize', () => {
     sandbox.restore()
   })
 
-  describe('when given a valid Google ID token', () => {
+  describe('when given a valid Google ID token in the body of a request', () => {
     beforeEach(async () => {
       this.fakeExpressResponse = mockResponse(sandbox)
       this.nextStub = sandbox.stub()
@@ -64,14 +64,99 @@ describe('googleHelpers.js unit tests: paAuthorize', () => {
     })
   })
 
-  describe('when given an invalid Google ID token', () => {
+  describe('when given a valid Google ID token in the Authorization header of a request', () => {
     beforeEach(async () => {
       this.fakeExpressResponse = mockResponse(sandbox)
       this.nextStub = sandbox.stub()
+      this.googleIdToken = mockGoogleIdTokenFactory({
+        validAudience: true,
+        validSignature: true,
+        validExpiry: true,
+        validProfile: true,
+      })
       await googleHelpers.paAuthorize(
         {
-          body: {
-            googleIdToken: mockGoogleIdTokenFactory({}), // {}: no valid options
+          get: header => {
+            if (header === 'Authorization') {
+              return `Bearer ${this.googleIdToken}`
+            }
+
+            return ''
+          },
+        },
+        this.fakeExpressResponse,
+        this.nextStub,
+      )
+    })
+
+    it('should not set the response status code', () => {
+      expect(this.fakeExpressResponse.status).not.to.be.called
+    })
+
+    it('should call the next function', () => {
+      expect(this.nextStub).to.be.called
+    })
+
+    it('should not log any information', () => {
+      expect(helpers.log).not.to.be.called
+    })
+  })
+
+  describe('when given an expired Google ID token', () => {
+    beforeEach(async () => {
+      this.fakeExpressResponse = mockResponse(sandbox)
+      this.nextStub = sandbox.stub()
+      this.googleIdToken = mockGoogleIdTokenFactory({
+        validAudience: true,
+        validSignature: true,
+        validExpiry: false,
+        validProfile: true,
+      })
+      await googleHelpers.paAuthorize(
+        {
+          body: { googleIdToken: this.googleIdToken },
+          get: () => '',
+          path: TEST_PATH,
+        },
+        this.fakeExpressResponse,
+        this.nextStub,
+      )
+    })
+
+    it('should set the response status code to 401', () => {
+      expect(this.fakeExpressResponse.status).to.be.calledWith(401)
+    })
+
+    it('should not call the next function', () => {
+      expect(this.nextStub).not.to.be.called
+    })
+
+    it('should log the unauthorized request', () => {
+      const now = Date.now() / 1000
+      const errorMessage = `Token used too late, ${now} > ${now - 3600}: ${this.googleIdToken}`
+
+      expect(helpers.log).to.be.calledWith(`Google OAuth2: Unauthorized request to ${TEST_PATH}: ${errorMessage}`)
+    })
+  })
+
+  describe('when given an invalid Google ID token (not from Brave)', () => {
+    beforeEach(async () => {
+      this.fakeExpressResponse = mockResponse(sandbox)
+      this.nextStub = sandbox.stub()
+      this.googleIdToken = mockGoogleIdTokenFactory({
+        validAudience: false,
+        validSignature: false,
+        validExpiry: true,
+        validProfile: false,
+      })
+      await googleHelpers.paAuthorize(
+        {
+          get: header => {
+            if (header === 'Authorization') {
+              return `Bearer ${this.googleIdToken}`
+            }
+
+            return ''
           },
           path: TEST_PATH,
         },
@@ -84,12 +169,12 @@ describe('googleHelpers.js unit tests: paAuthorize', () => {
       expect(this.fakeExpressResponse.status).to.be.calledWith(401)
     })
 
-    it("shouldn't call the next function", () => {
+    it('should not call the next function', () => {
       expect(this.nextStub).not.to.be.called
     })
 
     it('should log the unauthorized request', () => {
-      expect(helpers.log).to.be.calledWith(`PA: Not authorized: ${TEST_PATH}`)
+      expect(helpers.log).to.be.calledWith(`Google OAuth2: Unauthorized request to ${TEST_PATH}: Invalid Google ID Token`)
     })
   })
 
@@ -97,28 +182,19 @@ describe('googleHelpers.js unit tests: paAuthorize', () => {
     beforeEach(async () => {
       this.fakeExpressResponse = mockResponse(sandbox)
       this.nextStub = sandbox.stub()
-      await googleHelpers.paAuthorize(
-        {
-          body: {
-            googleIdToken: undefined,
-          },
-          path: TEST_PATH,
-        },
-        this.fakeExpressResponse,
-        this.nextStub,
-      )
+      await googleHelpers.paAuthorize({ path: TEST_PATH }, this.fakeExpressResponse, this.nextStub)
     })
 
-    it('should set the response status code to 400', () => {
-      expect(this.fakeExpressResponse.status).to.be.calledWith(400)
+    it('should set the response status code to 401', () => {
+      expect(this.fakeExpressResponse.status).to.be.calledWith(401)
     })
 
-    it("shouldn't call the next function", () => {
+    it('should not call the next function', () => {
       expect(this.nextStub).not.to.be.called
     })
 
     it('should log the unauthorized request', () => {
-      expect(helpers.log).to.be.calledWith(`PA: Not authorized: ${TEST_PATH}`)
+      expect(helpers.log).to.be.calledWith(`Google OAuth2: Unauthorized request to ${TEST_PATH}: Missing Google ID Token`)
     })
   })
 })


### PR DESCRIPTION
This PR allows PA API routes to be authenticated with the Authorization header, as opposed to submission in the body of a request.

The Authorization header has a 'Bearer' type, where a token can be submitted (as opposed to Basic where a username and password is submitted); thus, the Bearer type is used here.

Test Plan:
- [x] Authorization through this header works with BraveButton's new PA API routes
  - [x] Google ID Tokens from PA can be submitted under the Authorization header
  - [x] These tokens remain valid
- [x] Existing PA API routes that expect the Google ID Token to be submitted in the body of a request still work
- [x] Existing test cases pass