### PR TITLE
Add `isResettable` to Session model (CU-86drfmvrj).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `isResettable` to Session model (CU-86drfmvrj).
+
 ## [12.3.0] - 2024-01-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ An object representing a session. Contains the following fields:
 
 **respondedByPhoneNumber (string):** The phone number of the responder that replied to the alert this session describes; should be the database value `session.responded_by_phone_number`
 
-**device (object):** The device which generated this alert. Note: **button**, and **location** represent the same object as **device**.
+**device (object):** The device which this session belongs to. Note: **button**, and **location** represent the same object as **device**.
 
 **isResettable (boolean):** Whether or not this device can be reset by the client. This should be set to true if the device is acting strange.
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ An object representing a session. Contains the following fields:
 
 **respondedByPhoneNumber (string):** The phone number of the responder that replied to the alert this session describes; should be the database value `session.responded_by_phone_number`
 
+**device (object):** The device which generated this alert. Note: **button**, and **location** represent the same object as **device**.
+
+**isResettable (boolean):** Whether or not this device can be reset by the client. This should be set to true if the device is acting strange.
+
 ## `ALERT_TYPE` enum
 
 An enum of the possible types of alert that can be triggered.

--- a/lib/models/Session.js
+++ b/lib/models/Session.js
@@ -11,9 +11,11 @@ class Session {
     this.respondedAt = respondedAt
     this.respondedByPhoneNumber = respondedByPhoneNumber
 
-    // this is temporary: change these two lines to `this.device = device` when renaming buttons and locations table to devices table in both buttons and sensor
+    // remove these two assignments when both BraveButtons and BraveSensor use this.device
     this.button = device
     this.location = device
+
+    this.device = device
 
     this.isResettable = isResettable
   }

--- a/lib/models/Session.js
+++ b/lib/models/Session.js
@@ -1,6 +1,6 @@
 class Session {
   // prettier-ignore
-  constructor(id, chatbotState, alertType, numberOfAlerts, createdAt, updatedAt, incidentCategory, respondedAt, respondedByPhoneNumber, device) {
+  constructor(id, chatbotState, alertType, numberOfAlerts, createdAt, updatedAt, incidentCategory, respondedAt, respondedByPhoneNumber, device, isResettable) {
     this.id = id
     this.chatbotState = chatbotState
     this.alertType = alertType
@@ -14,6 +14,8 @@ class Session {
     // this is temporary: change these two lines to `this.device = device` when renaming buttons and locations table to devices table in both buttons and sensor
     this.button = device
     this.location = device
+
+    this.isResettable = isResettable
   }
 }
 

--- a/lib/models/Session.js
+++ b/lib/models/Session.js
@@ -1,6 +1,6 @@
 class Session {
   // prettier-ignore
-  constructor(id, chatbotState, alertType, numberOfAlerts, createdAt, updatedAt, incidentCategory, respondedAt, respondedByPhoneNumber, device, isResettable) {
+  constructor(id, chatbotState, alertType, numberOfAlerts, createdAt, updatedAt, incidentCategory, respondedAt, respondedByPhoneNumber, isResettable, device) {
     this.id = id
     this.chatbotState = chatbotState
     this.alertType = alertType
@@ -10,14 +10,12 @@ class Session {
     this.incidentCategory = incidentCategory
     this.respondedAt = respondedAt
     this.respondedByPhoneNumber = respondedByPhoneNumber
+    this.isResettable = isResettable
 
     // remove these two assignments when both BraveButtons and BraveSensor use this.device
     this.button = device
     this.location = device
-
     this.device = device
-
-    this.isResettable = isResettable
   }
 }
 


### PR DESCRIPTION
This PR adds `isResettable` to the Session model, which is primarily used for the BraveSensor reset chatbot flow ( [view PR](https://github.com/bravetechnologycoop/BraveSensor/pull/271) ).

Test Plan:
- [x] Existing test cases pass
- [ ] Test plan of parent PR is complete